### PR TITLE
Autolabel new Pull Requests

### DIFF
--- a/src/AppBundle/Controller/WebhookController.php
+++ b/src/AppBundle/Controller/WebhookController.php
@@ -40,7 +40,9 @@ class WebhookController extends Controller
                         $responseData = [
                             'pull_request' => $data['pull_request']['number'],
                             'status_change' => $listener->handlePullRequestCreatedEvent(
-                                $data['pull_request']['number']
+                                $data['pull_request']['number'],
+                                $data['pull_request']['title'],
+                                $data['pull_request']['body']
                             ),
                         ];
                         break;

--- a/src/AppBundle/Issues/GitHub/GitHubStatusApi.php
+++ b/src/AppBundle/Issues/GitHub/GitHubStatusApi.php
@@ -78,6 +78,20 @@ class GitHubStatusApi implements StatusApi
         }
     }
 
+    /**
+     * Replaces the existing issue labels (if any) with the given array of
+     * new labels. Use an empty array to remove all the existing labels.
+     *
+     * @param int    $issueNumber The GitHub issue number
+     * @param array  $newLabels
+     */
+    public function setIssueLabels($issueNumber, array $newLabels)
+    {
+        foreach ($newLabels as $label) {
+            $this->labelsApi->addIssueLabel($issueNumber, $label);
+        }
+    }
+
     public function getIssueStatus($issueNumber)
     {
         $currentLabels = $this->labelsApi->getIssueLabels($issueNumber);

--- a/src/AppBundle/Issues/IssueListener.php
+++ b/src/AppBundle/Issues/IssueListener.php
@@ -129,10 +129,10 @@ class IssueListener
         $labels = array();
 
         // e.g. "[PropertyAccess] [RFC] [WIP] Allow custom methods on property accesses"
-        if (preg_match_all('/\[(?P<tags>.+)\]/U', $prTitle, $matches)) {
-            foreach ($matches['tags'] as $tag) {
-                if (in_array($tag, $this->getValidTags())) {
-                    $labels[] = $tag;
+        if (preg_match_all('/\[(?P<labels>.+)\]/U', $prTitle, $matches)) {
+            foreach ($matches['labels'] as $label) {
+                if (in_array($label, $this->getValidLabels())) {
+                    $labels[] = $label;
                 }
             }
         }
@@ -141,9 +141,9 @@ class IssueListener
     }
 
     /**
-     * TODO: get valid tags from the repository via GitHub API
+     * TODO: get valid labels from the repository via GitHub API
      */
-    private function getValidTags()
+    private function getValidLabels()
     {
         return array(
             'Asset', 'BC Break', 'BrowserKit', 'Bug', 'Cache', 'ClassLoader',

--- a/src/AppBundle/Issues/IssueListener.php
+++ b/src/AppBundle/Issues/IssueListener.php
@@ -71,9 +71,9 @@ class IssueListener
         $newStatus = Status::NEEDS_REVIEW;
         $prLabels[] = $newStatus;
 
-        // the PR title usually indicates the affected component
-        if (preg_match('/^\[(?P<component>.*)\] .*/$', $prTitle, $matches)) {
-            $prLabels[] = $matches['component'];
+        // the PR title usually contains one or more labels
+        foreach ($this->extractLabels($prTitle) as $label) {
+            $prLabels[] = $label;
         }
 
         // the PR body usually indicates if this is a Bug, Feature, BC Break or Deprecation
@@ -122,5 +122,41 @@ class IssueListener
         $this->statusApi->setIssueStatus($issueNumber, $newStatus);
 
         return $newStatus;
+    }
+
+    private function extractLabels($prTitle)
+    {
+        $labels = array();
+
+        // e.g. "[PropertyAccess] [RFC] [WIP] Allow custom methods on property accesses"
+        if (preg_match_all('/\[(?P<tags>.+)\]/U', $prTitle, $matches)) {
+            foreach ($matches['tags'] as $tag) {
+                if (in_array($tag, $this->getValidTags())) {
+                    $labels[] = $tag;
+                }
+            }
+        }
+
+        return $labels;
+    }
+
+    /**
+     * TODO: get valid tags from the repository via GitHub API
+     */
+    private function getValidTags()
+    {
+        return array(
+            'Asset', 'BC Break', 'BrowserKit', 'Bug', 'Cache', 'ClassLoader',
+            'Config', 'Console', 'Critical', 'CssSelector', 'Debug', 'DebugBundle',
+            'DependencyInjection', 'Deprecation', 'Doctrine', 'DoctrineBridge',
+            'DomCrawler', 'Drupal related', 'DX', 'Easy Pick', 'Enhancement',
+            'EventDispatcher', 'ExpressionLanguage', 'Feature', 'Filesystem',
+            'Finder', 'Form', 'FrameworkBundle', 'HttpFoundation', 'HttpKernel',
+            'Intl', 'Ldap', 'Locale', 'MonologBridge', 'OptionsResolver',
+            'PhpUnitBridge', 'Process', 'PropertyAccess', 'PropertyInfo', 'Ready',
+            'RFC', 'Routing', 'Security', 'SecurityBundle', 'Serializer',
+            'Stopwatch', 'Templating', 'Translator', 'TwigBridge', 'TwigBundle',
+            'Unconfirmed', 'Validator', 'VarDumper', 'WebProfilerBundle', 'Yaml',
+        );
     }
 }

--- a/src/AppBundle/Issues/NullStatusApi.php
+++ b/src/AppBundle/Issues/NullStatusApi.php
@@ -15,6 +15,10 @@ class NullStatusApi implements StatusApi
     {
     }
 
+    public function setIssueLabels($issueNumber, array $newLabels)
+    {
+    }
+
     public function getNeedsReviewUrl()
     {
     }

--- a/src/AppBundle/Issues/StatusApi.php
+++ b/src/AppBundle/Issues/StatusApi.php
@@ -13,5 +13,7 @@ interface StatusApi
 
     public function setIssueStatus($issueNumber, $newStatus);
 
+    public function setIssueLabels($issueNumber, array $newLabels);
+
     public function getNeedsReviewUrl();
 }

--- a/src/AppBundle/Tests/Issues/IssueListenerTest.php
+++ b/src/AppBundle/Tests/Issues/IssueListenerTest.php
@@ -153,10 +153,10 @@ class IssueListenerTest extends \PHPUnit_Framework_TestCase
     public function testHandlePullRequestCreatedEvent()
     {
         $this->statusApi->expects($this->once())
-            ->method('setIssueStatus')
-            ->with(1234, Status::NEEDS_REVIEW);
+            ->method('setIssueLabels')
+            ->with(1234, array(Status::NEEDS_REVIEW));
 
-        $newStatus = $this->listener->handlePullRequestCreatedEvent(1234);
+        $newStatus = $this->listener->handlePullRequestCreatedEvent(1234, 'The title', 'The description.');
 
         $this->assertSame(Status::NEEDS_REVIEW, $newStatus);
     }


### PR DESCRIPTION
Two important things:

1) I haven't tested this in any way and I don't know how to test it in a real repository.

2) ~~What happens if you try to label an issue with a non-existent label? I guess it will be dropped silently. Otherwise, we'll have a problem if a user creates a PR with a title like this: "[Whatever] Blah blah"~~ FIXED in the latest version of this PR.