### PR TITLE
Enable auto label PR for the docs

### DIFF
--- a/app/config/github.yml
+++ b/app/config/github.yml
@@ -43,6 +43,7 @@ parameters:
                 - app.subscriber.status_change_on_push_subscriber
                 - app.subscriber.needs_review_new_pr_subscriber
                 - app.subscriber.bug_label_new_issue_subscriber
+                - app.subscriber.auto_label_pr_from_content_subscriber
             # secret: %symfony_docs_secret%
 
         # used in a functional test


### PR DESCRIPTION
We have component labels as well in the docs and people use `[Component]` tags too. Let's enable the subscriber :)
