### PR TITLE
Fixed InMemoryRepositoryProvider::getRepository()

### DIFF
--- a/src/AppBundle/Repository/Provider/InMemoryRepositoryProvider.php
+++ b/src/AppBundle/Repository/Provider/InMemoryRepositoryProvider.php
@@ -41,7 +41,9 @@ class InMemoryRepositoryProvider implements RepositoryProviderInterface
 
     public function getRepository($repositoryName)
     {
-        return isset($this->repositories[$repositoryName]) ? $this->repositories[$repositoryName] : null;
+        $repository = strtolower($repositoryName);
+
+        return isset($this->repositories[$repository]) ? $this->repositories[$repository] : null;
     }
 
     public function getAllRepositories()

--- a/src/AppBundle/Repository/Repository.php
+++ b/src/AppBundle/Repository/Repository.php
@@ -27,7 +27,7 @@ class Repository
     private $subscribers;
 
     /**
-     * The webhook secret  used by GitHub.
+     * The webhook secret used by GitHub.
      *
      * @var string
      */


### PR DESCRIPTION
Keys of the Repository collection are lowercased but the call does not normalize the argument.

This PR fixes it.