### PR TITLE
Consider "DI" an alias of "DependencyInjection" label

### DIFF
--- a/src/AppBundle/Subscriber/AutoLabelPRFromContentSubscriber.php
+++ b/src/AppBundle/Subscriber/AutoLabelPRFromContentSubscriber.php
@@ -78,6 +78,11 @@ class AutoLabelPRFromContentSubscriber implements EventSubscriberInterface
             );
 
             foreach ($matches['labels'] as $label) {
+                // it's common to use 'DI' for 'DependencyInjection'
+                if ('di' === strtolower($label)) {
+                    $label = 'DependencyInjection';
+                }
+                
                 // check case-insensitively, but the apply the correctly-cased label
                 if (isset($validLabels[strtolower($label)])) {
                     $labels[] = $validLabels[strtolower($label)];


### PR DESCRIPTION
I propose to fix just "DI" label because it's the only common case I know. If there were other cases, we should introduce a utility method to resolve these aliases.