### PR TITLE
Disabled status subscribers for the docs

### DIFF
--- a/app/config/github.yml
+++ b/app/config/github.yml
@@ -40,8 +40,8 @@ parameters:
         symfony/symfony-docs:
             subscribers:
                 - app.subscriber.status_change_by_comment_subscriber
-                - app.subscriber.status_change_on_push_subscriber
-                - app.subscriber.needs_review_new_pr_subscriber
+                #- app.subscriber.status_change_on_push_subscriber
+                #- app.subscriber.needs_review_new_pr_subscriber
                 - app.subscriber.bug_label_new_issue_subscriber
                 - app.subscriber.auto_label_pr_from_content_subscriber
             # secret: %symfony_docs_secret%


### PR DESCRIPTION
As proposed in our Slack channel, it's probably better to use the GitHub review API instead of the status labels in the docs.

This PR disables setting the `Needs Review` label on creation and pushing a new commit. I still enabled status change by comment, as status labels still make sense for bug reports imo.

/cc @javiereguiluz @weaverryan @xabbuh 