### PR TITLE
Do not enable label if PR body line is equal to "yes/no"

### DIFF
--- a/src/AppBundle/Subscriber/AutoLabelPRFromContentSubscriber.php
+++ b/src/AppBundle/Subscriber/AutoLabelPRFromContentSubscriber.php
@@ -52,16 +52,16 @@ class AutoLabelPRFromContentSubscriber implements EventSubscriberInterface
         }
 
         // the PR body usually indicates if this is a Bug, Feature, BC Break or Deprecation
-        if (preg_match('/\|\s*Bug fix\?\s*\|\s*yes\s*/i', $prBody, $matches)) {
+        if (preg_match('/\|\s*Bug fix\?\s*\|\s*(yes)(?!\/no)\s*/i', $prBody, $matches)) {
             $prLabels[] = 'Bug';
         }
-        if (preg_match('/\|\s*New feature\?\s*\|\s*yes\s*/i', $prBody, $matches)) {
+        if (preg_match('/\|\s*New feature\?\s*\|\s*(yes)(?!\/no)\s*/i', $prBody, $matches)) {
             $prLabels[] = 'Feature';
         }
-        if (preg_match('/\|\s*BC breaks\?\s*\|\s*yes\s*/i', $prBody, $matches)) {
+        if (preg_match('/\|\s*BC breaks\?\s*\|\s*(yes)(?!\/no)\s*/i', $prBody, $matches)) {
             $prLabels[] = 'BC Break';
         }
-        if (preg_match('/\|\s*Deprecations\?\s*\|\s*yes\s*/i', $prBody, $matches)) {
+        if (preg_match('/\|\s*Deprecations\?\s*\|\s*(yes)(?!\/no)\s*/i', $prBody, $matches)) {
             $prLabels[] = 'Deprecation';
         }
 

--- a/src/AppBundle/Tests/Subscriber/AutoLabelPRFromContentSubscriberTest.php
+++ b/src/AppBundle/Tests/Subscriber/AutoLabelPRFromContentSubscriberTest.php
@@ -143,6 +143,27 @@ EOF
         ];
 
         $tests[] = [
+            '"yes/no" are not "yes"',
+            <<<EOF
+Well hi cool peeps!
+
+| Q             | A
+| ------------- | ---
+| Branch?       | master
+| Bug fix?      | yes
+| New feature?  | yes/no
+| BC breaks?    | yes/no
+| Deprecations? | yes/no
+| Tests pass?   | yes/no
+| Fixed tickets | n/a
+| License       | MIT
+| Doc PR        | n/a
+EOF
+            ,
+            ['Bug'],
+        ];
+
+        $tests[] = [
             '[Asset][bc Break][Fake] Extracting from title [Bug]',
             <<<EOF
 EOF


### PR DESCRIPTION
Sometimes PR body isn't filled, it happened to me by mistake already (hit enter) and, when it isn't, all lines  equal to `yes/no` are interpreted as `yes` by carson , the result being that all possible labels are added to the PR and then one has to ask for relabelling.
See [remaining examples](https://github.com/symfony/symfony/pulls?utf8=%E2%9C%93&q=is%3Apr%20label%3AFeature%20label%3ABug%20label%3A%22BC%20Break%22%20label%3ADeprecation%20).