### PR TITLE
Make sure we got a new and clean dispatcher at each test

### DIFF
--- a/src/AppBundle/Tests/Subscriber/AutoLabelPRFromContentSubscriberTest.php
+++ b/src/AppBundle/Tests/Subscriber/AutoLabelPRFromContentSubscriberTest.php
@@ -19,12 +19,7 @@ class AutoLabelPRFromContentSubscriberTest extends \PHPUnit_Framework_TestCase
     /**
      * @var EventDispatcher
      */
-    private static $dispatcher;
-
-    public static function setUpBeforeClass()
-    {
-        self::$dispatcher = new EventDispatcher();
-    }
+    private $dispatcher;
 
     protected function setUp()
     {
@@ -34,7 +29,8 @@ class AutoLabelPRFromContentSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->autoLabelSubscriber = new AutoLabelPRFromContentSubscriber($this->labelsApi);
         $this->repository = new Repository('weaverryan', 'symfony', [], null);
 
-        self::$dispatcher->addSubscriber($this->autoLabelSubscriber);
+        $this->dispatcher = new EventDispatcher();
+        $this->dispatcher->addSubscriber($this->autoLabelSubscriber);
     }
 
     /**
@@ -56,7 +52,7 @@ class AutoLabelPRFromContentSubscriberTest extends \PHPUnit_Framework_TestCase
             ),
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
+        $this->dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
 
         $responseData = $event->getResponseData();
 

--- a/src/AppBundle/Tests/Subscriber/BugLabelNewIssueSubscriberTest.php
+++ b/src/AppBundle/Tests/Subscriber/BugLabelNewIssueSubscriberTest.php
@@ -20,12 +20,8 @@ class BugLabelNewIssueSubscriberTest extends \PHPUnit_Framework_TestCase
     /**
      * @var EventDispatcher
      */
-    private static $dispatcher;
+    private $dispatcher;
 
-    public static function setUpBeforeClass()
-    {
-        self::$dispatcher = new EventDispatcher();
-    }
 
     protected function setUp()
     {
@@ -33,7 +29,8 @@ class BugLabelNewIssueSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->bugLabelSubscriber = new BugLabelNewIssueSubscriber($this->statusApi);
         $this->repository = new Repository('weaverryan', 'symfony', [], null);
 
-        self::$dispatcher->addSubscriber($this->bugLabelSubscriber);
+        $this->dispatcher = new EventDispatcher();
+        $this->dispatcher->addSubscriber($this->bugLabelSubscriber);
     }
 
     public function testOnIssuesLabeledBug()
@@ -53,7 +50,7 @@ class BugLabelNewIssueSubscriberTest extends \PHPUnit_Framework_TestCase
             'label' => array('name' => 'bug'),
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::ISSUES, $event);
+        $this->dispatcher->dispatch(GitHubEvents::ISSUES, $event);
 
         $responseData = $event->getResponseData();
 
@@ -79,7 +76,7 @@ class BugLabelNewIssueSubscriberTest extends \PHPUnit_Framework_TestCase
             'label' => array('name' => 'BUG'),
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::ISSUES, $event);
+        $this->dispatcher->dispatch(GitHubEvents::ISSUES, $event);
 
         $responseData = $event->getResponseData();
 
@@ -102,7 +99,7 @@ class BugLabelNewIssueSubscriberTest extends \PHPUnit_Framework_TestCase
             'label' => array('name' => 'feature'),
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::ISSUES, $event);
+        $this->dispatcher->dispatch(GitHubEvents::ISSUES, $event);
 
         $responseData = $event->getResponseData();
 
@@ -127,7 +124,7 @@ class BugLabelNewIssueSubscriberTest extends \PHPUnit_Framework_TestCase
             'label' => array('name' => 'bug'),
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::ISSUES, $event);
+        $this->dispatcher->dispatch(GitHubEvents::ISSUES, $event);
 
         $responseData = $event->getResponseData();
 
@@ -150,7 +147,7 @@ class BugLabelNewIssueSubscriberTest extends \PHPUnit_Framework_TestCase
             'label' => array('name' => 'bug'),
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::ISSUES, $event);
+        $this->dispatcher->dispatch(GitHubEvents::ISSUES, $event);
 
         $responseData = $event->getResponseData();
 

--- a/src/AppBundle/Tests/Subscriber/NeedsReviewNewPRSubscriberTest.php
+++ b/src/AppBundle/Tests/Subscriber/NeedsReviewNewPRSubscriberTest.php
@@ -20,12 +20,7 @@ class NeedsReviewNewPRSubscriberTest extends \PHPUnit_Framework_TestCase
     /**
      * @var EventDispatcher
      */
-    private static $dispatcher;
-
-    public static function setUpBeforeClass()
-    {
-        self::$dispatcher = new EventDispatcher();
-    }
+    private $dispatcher;
 
     protected function setUp()
     {
@@ -33,7 +28,8 @@ class NeedsReviewNewPRSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->needsReviewSubscriber = new NeedsReviewNewPRSubscriber($this->statusApi);
         $this->repository = new Repository('weaverryan', 'symfony', [], null);
 
-        self::$dispatcher->addSubscriber($this->needsReviewSubscriber);
+        $this->dispatcher = new EventDispatcher();
+        $this->dispatcher->addSubscriber($this->needsReviewSubscriber);
     }
 
     public function testOnPullRequestOpen()
@@ -47,7 +43,7 @@ class NeedsReviewNewPRSubscriberTest extends \PHPUnit_Framework_TestCase
             'pull_request' => array('number' => 1234),
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
+        $this->dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
 
         $responseData = $event->getResponseData();
 
@@ -65,7 +61,7 @@ class NeedsReviewNewPRSubscriberTest extends \PHPUnit_Framework_TestCase
             'action' => 'close',
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
+        $this->dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
 
         $responseData = $event->getResponseData();
 

--- a/src/AppBundle/Tests/Subscriber/StatusChangeByCommentSubscriberTest.php
+++ b/src/AppBundle/Tests/Subscriber/StatusChangeByCommentSubscriberTest.php
@@ -20,12 +20,7 @@ class StatusChangeByCommentSubscriberTest extends \PHPUnit_Framework_TestCase
     /**
      * @var EventDispatcher
      */
-    private static $dispatcher;
-
-    public static function setUpBeforeClass()
-    {
-        self::$dispatcher = new EventDispatcher();
-    }
+    private $dispatcher;
 
     protected function setUp()
     {
@@ -34,7 +29,8 @@ class StatusChangeByCommentSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->statusChangeSubscriber = new StatusChangeByCommentSubscriber($this->statusApi, $logger);
         $this->repository = new Repository('weaverryan', 'symfony', [], null);
 
-        self::$dispatcher->addSubscriber($this->statusChangeSubscriber);
+        $this->dispatcher = new EventDispatcher();
+        $this->dispatcher->addSubscriber($this->statusChangeSubscriber);
     }
 
     /**
@@ -53,7 +49,7 @@ class StatusChangeByCommentSubscriberTest extends \PHPUnit_Framework_TestCase
             'comment' => array('body' => $comment, 'user' => ['login' => 'leannapelham']),
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::ISSUE_COMMENT, $event);
+        $this->dispatcher->dispatch(GitHubEvents::ISSUE_COMMENT, $event);
 
         $responseData = $event->getResponseData();
 
@@ -121,7 +117,7 @@ class StatusChangeByCommentSubscriberTest extends \PHPUnit_Framework_TestCase
             ),
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::ISSUE_COMMENT, $event);
+        $this->dispatcher->dispatch(GitHubEvents::ISSUE_COMMENT, $event);
 
         $responseData = $event->getResponseData();
 

--- a/src/AppBundle/Tests/Subscriber/StatusChangeOnPushSubscriberTest.php
+++ b/src/AppBundle/Tests/Subscriber/StatusChangeOnPushSubscriberTest.php
@@ -20,12 +20,8 @@ class StatusChangeOnPushSubscriberTest extends \PHPUnit_Framework_TestCase
     /**
      * @var EventDispatcher
      */
-    private static $dispatcher;
+    private $dispatcher;
 
-    public static function setUpBeforeClass()
-    {
-        self::$dispatcher = new EventDispatcher();
-    }
 
     protected function setUp()
     {
@@ -33,7 +29,8 @@ class StatusChangeOnPushSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->statusChangeSubscriber = new StatusChangeOnPushSubscriber($this->statusApi);
         $this->repository = new Repository('weaverryan', 'symfony', [], null);
 
-        self::$dispatcher->addSubscriber($this->statusChangeSubscriber);
+        $this->dispatcher = new EventDispatcher();
+        $this->dispatcher->addSubscriber($this->statusChangeSubscriber);
     }
 
     /**
@@ -57,7 +54,7 @@ class StatusChangeOnPushSubscriberTest extends \PHPUnit_Framework_TestCase
             'pull_request' => $this->getPullRequestData(),
         ], $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
+        $this->dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
 
         $responseData = $event->getResponseData();
 
@@ -88,7 +85,7 @@ class StatusChangeOnPushSubscriberTest extends \PHPUnit_Framework_TestCase
             'pull_request' => $this->getPullRequestData(),
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
+        $this->dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
 
         $responseData = $event->getResponseData();
 
@@ -108,7 +105,7 @@ class StatusChangeOnPushSubscriberTest extends \PHPUnit_Framework_TestCase
             'pull_request' => $this->getPullRequestData('[wip] needs some more work.'),
         ), $this->repository);
 
-        self::$dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
+        $this->dispatcher->dispatch(GitHubEvents::PULL_REQUEST, $event);
 
         $responseData = $event->getResponseData();
 


### PR DESCRIPTION
While creating #68 I found some issues when the `self::$dispatcher` still had old subscribers on it. 

This PR will make sure we always got a new `EventDispatcher` at each test run. 