### PR TITLE
Add a custom retry strategy to retry 404

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "symfony/dotenv": "^5.1",
         "symfony/flex": "^1.8",
         "symfony/framework-bundle": "^5.1",
-        "symfony/http-client": "^5.1",
+        "symfony/http-client": "^v5.2.0-BETA3",
         "symfony/monolog-bundle": "~3.5",
         "symfony/security-core": "5.1.*",
         "symfony/twig-pack": "^1.0",
@@ -38,7 +38,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": true,
-            "require": "5.1.*"
+            "require": "^5.1"
         }
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd01536ce0c1a679d6ca79f0dd9fe10e",
+    "content-hash": "fbcf0079a54aa5883bd004b8b1793684",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -207,10 +207,6 @@
                 "parser",
                 "php"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/1.2.1"
-            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -276,10 +272,6 @@
             "keywords": [
                 "parameters management"
             ],
-            "support": {
-                "issues": "https://github.com/Incenteev/ParameterHandler/issues",
-                "source": "https://github.com/Incenteev/ParameterHandler/tree/v2.1.4"
-            },
             "time": "2020-03-17T21:10:00+00:00"
         },
         {
@@ -923,10 +915,6 @@
                 "stream",
                 "uri"
             ],
-            "support": {
-                "issues": "https://github.com/php-http/message-factory/issues",
-                "source": "https://github.com/php-http/message-factory/tree/master"
-            },
             "time": "2015-12-19T14:08:53+00:00"
         },
         {
@@ -1030,9 +1018,6 @@
                 "psr",
                 "psr-6"
             ],
-            "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
-            },
             "time": "2016-08-06T20:24:11+00:00"
         },
         {
@@ -1082,10 +1067,6 @@
                 "container-interop",
                 "psr"
             ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
-            },
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
@@ -1132,10 +1113,6 @@
                 "psr",
                 "psr-14"
             ],
-            "support": {
-                "issues": "https://github.com/php-fig/event-dispatcher/issues",
-                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
-            },
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
@@ -1240,9 +1217,6 @@
                 "request",
                 "response"
             ],
-            "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/master"
-            },
             "time": "2019-04-30T12:38:16+00:00"
         },
         {
@@ -1293,9 +1267,6 @@
                 "request",
                 "response"
             ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
-            },
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
@@ -1343,9 +1314,6 @@
                 "psr",
                 "psr-3"
             ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.3"
-            },
             "time": "2020-03-23T09:12:05+00:00"
         },
         {
@@ -2563,16 +2531,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v5.1.8",
+            "version": "v5.2.0-BETA3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "97a6a1f9f5bb3a6094833107b58a72bc9a9165cc"
+                "reference": "281d6be8fae0c5f9f5dc240e367efb0baf9eda9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/97a6a1f9f5bb3a6094833107b58a72bc9a9165cc",
-                "reference": "97a6a1f9f5bb3a6094833107b58a72bc9a9165cc",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/281d6be8fae0c5f9f5dc240e367efb0baf9eda9b",
+                "reference": "281d6be8fae0c5f9f5dc240e367efb0baf9eda9b",
                 "shasum": ""
             },
             "require": {
@@ -2590,6 +2558,7 @@
                 "symfony/http-client-implementation": "1.1"
             },
             "require-dev": {
+                "amphp/amp": "^2.5",
                 "amphp/http-client": "^4.2.1",
                 "amphp/http-tunnel": "^1.0",
                 "amphp/socket": "^1.1",
@@ -2599,7 +2568,8 @@
                 "psr/http-client": "^1.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
                 "symfony/http-kernel": "^4.4.13|^5.1.5",
-                "symfony/process": "^4.4|^5.0"
+                "symfony/process": "^4.4|^5.0",
+                "symfony/stopwatch": "^4.4|^5.0"
             },
             "type": "library",
             "autoload": {
@@ -2626,9 +2596,6 @@
             ],
             "description": "Symfony HttpClient component",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/http-client/tree/v5.1.8"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2643,7 +2610,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:01:57+00:00"
+            "time": "2020-10-24T12:08:07+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -3783,9 +3750,6 @@
             ],
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/security-core/tree/v5.1.8"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4981,7 +4945,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "symfony/http-client": 10
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -4991,5 +4957,5 @@
     "platform-overrides": {
         "php": "7.2.9"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/config/packages/github_api.yaml
+++ b/config/packages/github_api.yaml
@@ -7,6 +7,26 @@ services:
 
     Github\HttpClient\Builder:
         arguments:
-            - '@?Http\Client\HttpClient'
-            - '@?Http\Message\RequestFactory'
-            - '@?Http\Message\StreamFactory'
+            - '@github.httplug_client'
+            - '@Http\Message\RequestFactory'
+            - '@Http\Message\StreamFactory'
+
+    github.httplug_client:
+        class: Symfony\Component\HttpClient\HttplugClient
+        arguments:
+            - '@github.retryable_client'
+            - '@Psr\Http\Message\ResponseFactoryInterface'
+            - '@Psr\Http\Message\StreamFactoryInterface'
+
+    github.retryable_client:
+        class: Symfony\Component\HttpClient\RetryableHttpClient
+        arguments:
+            - '@http_client'
+            - '@github.retry_strategy'
+            - 2
+            - '@logger'
+
+    github.retry_strategy:
+        class: Symfony\Component\HttpClient\Retry\GenericRetryStrategy
+        arguments:
+            - [0, 404, 423, 425, 429, 500, 502, 503, 504, 507, 510]

--- a/src/Issues/GitHub/GitHubStatusApi.php
+++ b/src/Issues/GitHub/GitHubStatusApi.php
@@ -45,20 +45,12 @@ class GitHubStatusApi implements StatusApi
         }
 
         $newLabel = null === $newStatus ? null : self::$statusToLabel[$newStatus];
-        $this->logger->info(sprintf(
-            'Fetching issue labels for issue %s, repository %s',
-            $issueNumber,
-            $repository->getFullName()
-        ));
+        $this->logger->info(sprintf('Fetching issue labels for issue %s, repository %s', $issueNumber, $repository->getFullName()));
         $currentLabels = $this->labelsApi->getIssueLabels($issueNumber, $repository);
 
-        $this->logger->info(sprintf(
-            'Fetched the following labels: %s',
-            implode(', ', $currentLabels)
-        ));
+        $this->logger->info(sprintf('Fetched the following labels: %s', implode(', ', $currentLabels)));
 
         $addLabel = true;
-
         foreach ($currentLabels as $label) {
             // Ignore non-status, except when the bug is reviewed
             // but still marked as unconfirmed.
@@ -75,23 +67,13 @@ class GitHubStatusApi implements StatusApi
             }
 
             // Remove other statuses
-            $this->logger->debug(sprintf(
-                'Removing label %s from issue %s on repository %s',
-                $label,
-                $issueNumber,
-                $repository->getFullName()
-            ));
+            $this->logger->debug(sprintf('Removing label %s from issue %s on repository %s', $label, $issueNumber, $repository->getFullName()));
             $this->labelsApi->removeIssueLabel($issueNumber, $label, $repository);
         }
 
         // Ignored if the label is already set
         if ($addLabel && $newLabel) {
-            $this->logger->debug(sprintf(
-                'Adding label "%s" to issue %s on repository %s',
-                $newLabel,
-                $issueNumber,
-                $repository->getFullName()
-            ));
+            $this->logger->debug(sprintf('Adding label "%s" to issue %s on repository %s', $newLabel, $issueNumber, $repository->getFullName()));
             $this->labelsApi->addIssueLabel($issueNumber, $newLabel, $repository);
             $this->logger->debug('Label added!');
         }
@@ -108,7 +90,7 @@ class GitHubStatusApi implements StatusApi
         }
 
         // No status set
-        return;
+        return null;
     }
 
     public static function getNeedsReviewLabel()


### PR DESCRIPTION
### Problem
Sometimes, we get a webhook request and then we trying to ask the Github api for that issue, but the API says 404.

### Acknowledgement

I know I do more service definitions than needed, but I didnt want to pull in FrameworkBundle:5.2

### Excuse 

The changes in src/Issues/GitHub/GitHubStatusApi.php is just CS.. I started to read/think there before I ended up with the RetryStrategy solution

### Shout out


@jderusse, this is really awesome =)
