### PR TITLE
Comment on stale issues

### DIFF
--- a/.symfony.cloud.yaml
+++ b/.symfony.cloud.yaml
@@ -38,5 +38,13 @@ crons:
         spec: '*/5 * * * *'
         cmd: croncape bin/console app:task:run
 
+    stale_issues_symfony:
+        spec: '58 12 * * *'
+        cmd: croncape bin/console app:issue:ping-stale symfony/symfony
+
+    stale_issues_docs:
+        spec: '48 12 * * *'
+        cmd: croncape bin/console app:issue:ping-stale symfony/symfony-docs
+
 relationships:
     database: "mydatabase:postgresql"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,6 +11,7 @@ parameters:
                 - 'App\Subscriber\MilestoneNewPRSubscriber'
                 - 'App\Subscriber\WelcomeFirstTimeContributorSubscriber'
                 - 'App\Subscriber\CloseDraftPRSubscriber'
+                - 'App\Subscriber\RemoveStaledLabelOnCommentSubscriber'
             secret: '%env(SYMFONY_SECRET)%'
 
         symfony/symfony-docs:
@@ -23,6 +24,7 @@ parameters:
                 - 'App\Subscriber\BugLabelNewIssueSubscriber'
                 - 'App\Subscriber\AutoLabelFromContentSubscriber'
                 - 'subscriber.symfony_docs.milestone'
+                - 'App\Subscriber\RemoveStaledLabelOnCommentSubscriber'
             secret: '%env(SYMFONY_DOCS_SECRET)%'
 
         # used in a functional test
@@ -38,6 +40,7 @@ parameters:
                 - 'App\Subscriber\MilestoneNewPRSubscriber'
                 - 'App\Subscriber\WelcomeFirstTimeContributorSubscriber'
                 - 'App\Subscriber\CloseDraftPRSubscriber'
+                - 'App\Subscriber\RemoveStaledLabelOnCommentSubscriber'
 
 services:
     _defaults:

--- a/src/Api/Issue/IssueApi.php
+++ b/src/Api/Issue/IssueApi.php
@@ -21,6 +21,10 @@ interface IssueApi
 
     public function commentOnIssue(Repository $repository, $issueNumber, string $commentBody);
 
+    public function lastCommentWasMadeByBot(Repository $repository, $number): bool;
+
+    public function findStaleIssues(Repository $repository, \DateTimeImmutable $noUpdateAfter): array;
+
     /**
      * Close an issue or a pull request.
      */

--- a/src/Api/Issue/IssueType.php
+++ b/src/Api/Issue/IssueType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Api\Issue;
+
+class IssueType
+{
+    public const BUG = 'Bug';
+    public const FEATURE = 'Feature';
+    public const UNKNOWN = 'Unknown';
+    public const RFC = 'RFC';
+}

--- a/src/Api/Issue/NullIssueApi.php
+++ b/src/Api/Issue/NullIssueApi.php
@@ -19,6 +19,16 @@ class NullIssueApi implements IssueApi
     {
     }
 
+    public function lastCommentWasMadeByBot(Repository $repository, $number): bool
+    {
+        return false;
+    }
+
+    public function findStaleIssues(Repository $repository, \DateTimeImmutable $noUpdateAfter): array
+    {
+        return [];
+    }
+
     public function close(Repository $repository, $issueNumber)
     {
     }

--- a/src/Command/PingStaleIssuesCommand.php
+++ b/src/Command/PingStaleIssuesCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Command;
+
+use App\Api\Issue\IssueApi;
+use App\Api\Issue\IssueType;
+use App\Api\Label\LabelApi;
+use App\Entity\Task;
+use App\Service\RepositoryProvider;
+use App\Service\StaleIssueCommentGenerator;
+use App\Service\TaskScheduler;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Close issues not been updated in a long while.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class PingStaleIssuesCommand extends Command
+{
+    public const STALE_IF_NOT_UPDATED_SINCE = '-12months';
+    public const MESSAGE_TWO_AFTER = '+2weeks';
+    public const MESSAGE_THREE_AND_CLOSE_AFTER = '+2weeks';
+
+    protected static $defaultName = 'app:issue:ping-stale';
+
+    private $repositoryProvider;
+    private $issueApi;
+    private $scheduler;
+    private $commentGenerator;
+    private $labelApi;
+
+    public function __construct(RepositoryProvider $repositoryProvider, IssueApi $issueApi, TaskScheduler $scheduler, StaleIssueCommentGenerator $commentGenerator, LabelApi $labelApi)
+    {
+        parent::__construct();
+        $this->repositoryProvider = $repositoryProvider;
+        $this->issueApi = $issueApi;
+        $this->scheduler = $scheduler;
+        $this->commentGenerator = $commentGenerator;
+        $this->labelApi = $labelApi;
+    }
+
+    protected function configure()
+    {
+        $this->addArgument('repository', InputArgument::REQUIRED, 'The full name to the repository, eg symfony/symfony-docs');
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do a test search without making any comments or changes');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var string $repositoryName */
+        $repositoryName = $input->getArgument('repository');
+        $repository = $this->repositoryProvider->getRepository($repositoryName);
+        if (null === $repository) {
+            $output->writeln('Repository not configured');
+
+            return 1;
+        }
+
+        $notUpdatedAfter = new \DateTimeImmutable(self::STALE_IF_NOT_UPDATED_SINCE);
+        $issues = $this->issueApi->findStaleIssues($repository, $notUpdatedAfter);
+
+        if ($input->getOption('dry-run')) {
+            foreach ($issues as $issue) {
+                $output->writeln(sprintf('Marking issue #%s as "Staled". Link https://github.com/%s/issues/%s', $issue['number'], $repository->getFullName(), $issue['number']));
+            }
+
+            return 0;
+        }
+
+        foreach ($issues as $issue) {
+            $comment = $this->commentGenerator->getComment($this->extractType($issue));
+            $this->issueApi->commentOnIssue($repository, $issue['number'], $comment);
+            $this->labelApi->addIssueLabel($issue['number'], 'Staled', $repository);
+
+            // add a scheduled task to process this issue again after 2 weeks
+            $this->scheduler->runLater($repository, $issue['number'], Task::ACTION_INFORM_CLOSE_STALE, new \DateTimeImmutable(self::MESSAGE_TWO_AFTER));
+        }
+
+        return 0;
+    }
+
+    /**
+     * Extract type from issue array. Make sure we priorities labels if there are
+     * more than one type defined.
+     */
+    private function extractType(array $issue)
+    {
+        $types = [
+            IssueType::FEATURE => false,
+            IssueType::BUG => false,
+            IssueType::RFC => false,
+        ];
+
+        foreach ($issue['labels'] as $label) {
+            if (isset($types[$label['name']])) {
+                $types[$label['name']] = true;
+            }
+        }
+
+        foreach ($types as $type => $exists) {
+            if ($exists) {
+                return $type;
+            }
+        }
+
+        return IssueType::UNKNOWN;
+    }
+}

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -17,6 +17,7 @@ class Task
 {
     const ACTION_CLOSE_STALE = 1;
     const ACTION_CLOSE_DRAFT = 2;
+    const ACTION_INFORM_CLOSE_STALE = 3;
 
     /**
      * @var int

--- a/src/Service/RepositoryProvider.php
+++ b/src/Service/RepositoryProvider.php
@@ -9,6 +9,9 @@ use App\Model\Repository;
  */
 class RepositoryProvider
 {
+    /**
+     * @var Repository[]
+     */
     private $repositories = [];
 
     public function __construct(array $repositories)

--- a/src/Service/StaleIssueCommentGenerator.php
+++ b/src/Service/StaleIssueCommentGenerator.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Api\Issue\IssueType;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class StaleIssueCommentGenerator
+{
+    /**
+     * Get a comment to say: "I will close this soon".
+     */
+    public function getInformAboutClosingComment(): string
+    {
+        $messages = [
+            'Hello? This issue is about to be closed if nobody replies.',
+            'Friendly ping? Should this still be open? I will close if I don\'t hear anything.',
+            'Could I get a reply or should I close this?',
+            'Just a quick reminder to make a comment on this. If I don\'t hear anything I\'ll close this.',
+            'Friendly reminder that this issue exists. If I don\'t hear anything I\'ll close this.',
+            'Could I get an answer? If I do not hear anything I will assume this issue is resolved or abandoned. Please get back to me <3',
+        ];
+
+        return $messages[array_rand($messages)];
+    }
+
+    /**
+     * Get a comment to say: "I'm closing this now".
+     */
+    public function getClosingComment(): string
+    {
+        return <<<TXT
+Hey,
+
+I didn't hear anything so I'm going to close it. Feel free to comment if this is still relevant, I can always reopen!
+TXT;
+    }
+
+    /**
+     * Get a comment that encourage users to reply or close the issue themselves.
+     *
+     * @param string $type Valid types are IssueType::*
+     */
+    public function getComment(string $type): string
+    {
+        switch ($type) {
+            case IssueType::BUG:
+                return $this->bug();
+            case IssueType::FEATURE:
+            case IssueType::RFC:
+                return $this->feature();
+            default:
+                return $this->unknown();
+        }
+    }
+
+    private function bug(): string
+    {
+        return <<<TXT
+Hey, thanks for your report!
+There has not been a lot of activity here for a while. Is this bug still relevant? Have you managed to find a workaround?
+TXT;
+    }
+
+    private function feature(): string
+    {
+        return <<<TXT
+Thank you for this suggestion.
+There has not been a lot of activity here for a while. Would you still like to see this feature?
+TXT;
+    }
+
+    private function unknown(): string
+    {
+        return <<<TXT
+Thank you for this issue.
+There has not been a lot of activity here for a while. Has this been resolved?
+TXT;
+    }
+}

--- a/src/Service/TaskHandler/CloseStaleIssuesHandler.php
+++ b/src/Service/TaskHandler/CloseStaleIssuesHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\TaskHandler;
+
+use App\Api\Issue\IssueApi;
+use App\Api\Label\LabelApi;
+use App\Entity\Task;
+use App\Service\RepositoryProvider;
+use App\Service\StaleIssueCommentGenerator;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class CloseStaleIssuesHandler implements TaskHandlerInterface
+{
+    private $issueApi;
+    private $repositoryProvider;
+    private $labelApi;
+    private $commentGenerator;
+
+    public function __construct(LabelApi $labelApi, IssueApi $issueApi, RepositoryProvider $repositoryProvider, StaleIssueCommentGenerator $commentGenerator)
+    {
+        $this->issueApi = $issueApi;
+        $this->repositoryProvider = $repositoryProvider;
+        $this->labelApi = $labelApi;
+        $this->commentGenerator = $commentGenerator;
+    }
+
+    /**
+     * Close the issue if the last comment was made by the bot and if "Keep open" label does not exist.
+     */
+    public function handle(Task $task): void
+    {
+        if (null === $repository = $this->repositoryProvider->getRepository($task->getRepositoryFullName())) {
+            return;
+        }
+        $labels = $this->labelApi->getIssueLabels($task->getNumber(), $repository);
+        if (in_array('Keep open', $labels)) {
+            $this->labelApi->removeIssueLabel($task->getNumber(), 'Staled', $repository);
+
+            return;
+        }
+
+        if ($this->issueApi->lastCommentWasMadeByBot($repository, $task->getNumber())) {
+            $this->issueApi->commentOnIssue($repository, $task->getNumber(), $this->commentGenerator->getClosingComment());
+            $this->issueApi->close($repository, $task->getNumber());
+        } else {
+            $this->labelApi->removeIssueLabel($task->getNumber(), 'Staled', $repository);
+        }
+    }
+
+    public function supports(Task $task): bool
+    {
+        return Task::ACTION_CLOSE_STALE === $task->getAction();
+    }
+}

--- a/src/Service/TaskHandler/InformAboutClosingStaleIssuesHandler.php
+++ b/src/Service/TaskHandler/InformAboutClosingStaleIssuesHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\TaskHandler;
+
+use App\Api\Issue\IssueApi;
+use App\Api\Label\LabelApi;
+use App\Command\PingStaleIssuesCommand;
+use App\Entity\Task;
+use App\Service\RepositoryProvider;
+use App\Service\StaleIssueCommentGenerator;
+use App\Service\TaskScheduler;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class InformAboutClosingStaleIssuesHandler implements TaskHandlerInterface
+{
+    private $issueApi;
+    private $repositoryProvider;
+    private $labelApi;
+    private $commentGenerator;
+    private $scheduler;
+
+    public function __construct(LabelApi $labelApi, IssueApi $issueApi, RepositoryProvider $repositoryProvider, StaleIssueCommentGenerator $commentGenerator, TaskScheduler $scheduler)
+    {
+        $this->issueApi = $issueApi;
+        $this->repositoryProvider = $repositoryProvider;
+        $this->labelApi = $labelApi;
+        $this->commentGenerator = $commentGenerator;
+        $this->scheduler = $scheduler;
+    }
+
+    /**
+     * Close the issue if the last comment was made by the bot and if "Keep open" label does not exist.
+     */
+    public function handle(Task $task): void
+    {
+        if (null === $repository = $this->repositoryProvider->getRepository($task->getRepositoryFullName())) {
+            return;
+        }
+        $labels = $this->labelApi->getIssueLabels($task->getNumber(), $repository);
+        if (in_array('Keep open', $labels)) {
+            $this->labelApi->removeIssueLabel($task->getNumber(), 'Staled', $repository);
+
+            return;
+        }
+
+        if ($this->issueApi->lastCommentWasMadeByBot($repository, $task->getNumber())) {
+            $this->issueApi->commentOnIssue($repository, $task->getNumber(), $this->commentGenerator->getInformAboutClosingComment());
+            $this->scheduler->runLater($repository, $task->getNumber(), Task::ACTION_CLOSE_STALE, new \DateTimeImmutable(PingStaleIssuesCommand::MESSAGE_THREE_AND_CLOSE_AFTER));
+        } else {
+            $this->labelApi->removeIssueLabel($task->getNumber(), 'Staled', $repository);
+        }
+    }
+
+    public function supports(Task $task): bool
+    {
+        return Task::ACTION_INFORM_CLOSE_STALE === $task->getAction();
+    }
+}

--- a/src/Subscriber/RemoveStaledLabelOnCommentSubscriber.php
+++ b/src/Subscriber/RemoveStaledLabelOnCommentSubscriber.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Subscriber;
+
+use App\Api\Label\LabelApi;
+use App\Event\GitHubEvent;
+use App\GitHubEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * If somebody (not the bot) makes a comment on an issue that is stale, then remove
+ * the stale label.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class RemoveStaledLabelOnCommentSubscriber implements EventSubscriberInterface
+{
+    private $labelApi;
+    private $botUsername;
+
+    public function __construct(LabelApi $labelApi, string $botUsername)
+    {
+        $this->labelApi = $labelApi;
+        $this->botUsername = $botUsername;
+    }
+
+    public function onIssueComment(GitHubEvent $event)
+    {
+        $data = $event->getData();
+        $repository = $event->getRepository();
+
+        // If bot, then nothing.
+        if ($data['comment']['user']['login'] === $this->botUsername) {
+            return;
+        }
+
+        $removed = false;
+        $issueNumber = $data['issue']['number'];
+        foreach ($data['issue']['labels'] as $label) {
+            if ('Staled' === $label['name']) {
+                $removed = true;
+                $this->labelApi->removeIssueLabel($issueNumber, 'Staled', $repository);
+            }
+        }
+
+        if ($removed) {
+            $event->setResponseData([
+                'issue' => $issueNumber,
+                'removed_staled_label' => true,
+            ]);
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            GitHubEvents::ISSUE_COMMENT => 'onIssueComment',
+        ];
+    }
+}

--- a/tests/Service/TaskHandler/CloseStaleIssuesHandlerTest.php
+++ b/tests/Service/TaskHandler/CloseStaleIssuesHandlerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Service\TaskHandler;
+
+use App\Api\Issue\NullIssueApi;
+use App\Api\Label\NullLabelApi;
+use App\Entity\Task;
+use App\Service\RepositoryProvider;
+use App\Service\StaleIssueCommentGenerator;
+use App\Service\TaskHandler\CloseStaleIssuesHandler;
+use PHPUnit\Framework\TestCase;
+
+class CloseStaleIssuesHandlerTest extends TestCase
+{
+    public function testHandleKeepOpen()
+    {
+        $labelApi = $this->getMockBuilder(NullLabelApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIssueLabels', 'lastCommentWasMadeByBot'])
+            ->getMock();
+        $labelApi->expects($this->any())->method('getIssueLabels')->willReturn(['Bug', 'Keep open']);
+
+        $issueApi = $this->getMockBuilder(NullIssueApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['close', 'lastCommentWasMadeByBot'])
+            ->getMock();
+        $issueApi->expects($this->any())->method('lastCommentWasMadeByBot')->willReturn(true);
+        $issueApi->expects($this->never())->method('close');
+
+        $repoProvider = new RepositoryProvider(['carsonbot-playground/symfony' => []]);
+
+        $handler = new CloseStaleIssuesHandler($labelApi, $issueApi, $repoProvider, new StaleIssueCommentGenerator());
+        $handler->handle(new Task('carsonbot-playground/symfony', 4711, Task::ACTION_CLOSE_STALE, new \DateTimeImmutable()));
+    }
+
+    public function testHandleComments()
+    {
+        $labelApi = $this->getMockBuilder(NullLabelApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIssueLabels', 'lastCommentWasMadeByBot'])
+            ->getMock();
+        $labelApi->expects($this->any())->method('getIssueLabels')->willReturn(['Bug']);
+
+        $issueApi = $this->getMockBuilder(NullIssueApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['close', 'lastCommentWasMadeByBot'])
+            ->getMock();
+        $issueApi->expects($this->any())->method('lastCommentWasMadeByBot')->willReturn(false);
+        $issueApi->expects($this->never())->method('close');
+
+        $repoProvider = new RepositoryProvider(['carsonbot-playground/symfony' => []]);
+
+        $handler = new CloseStaleIssuesHandler($labelApi, $issueApi, $repoProvider, new StaleIssueCommentGenerator());
+        $handler->handle(new Task('carsonbot-playground/symfony', 4711, Task::ACTION_CLOSE_STALE, new \DateTimeImmutable()));
+    }
+
+    public function testHandleStale()
+    {
+        $labelApi = $this->getMockBuilder(NullLabelApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIssueLabels'])
+            ->getMock();
+        $labelApi->expects($this->any())->method('getIssueLabels')->willReturn(['Bug']);
+
+        $issueApi = $this->getMockBuilder(NullIssueApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['close', 'lastCommentWasMadeByBot'])
+            ->getMock();
+        $issueApi->expects($this->any())->method('lastCommentWasMadeByBot')->willReturn(true);
+        $issueApi->expects($this->once())->method('close');
+
+        $repoProvider = new RepositoryProvider(['carsonbot-playground/symfony' => []]);
+
+        $handler = new CloseStaleIssuesHandler($labelApi, $issueApi, $repoProvider, new StaleIssueCommentGenerator());
+        $handler->handle(new Task('carsonbot-playground/symfony', 4711, Task::ACTION_CLOSE_STALE, new \DateTimeImmutable()));
+    }
+}

--- a/tests/Service/TaskHandler/InformAboutClosingStaleIssuesHandlerTest.php
+++ b/tests/Service/TaskHandler/InformAboutClosingStaleIssuesHandlerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Service\TaskHandler;
+
+use App\Api\Issue\NullIssueApi;
+use App\Api\Label\NullLabelApi;
+use App\Entity\Task;
+use App\Service\RepositoryProvider;
+use App\Service\StaleIssueCommentGenerator;
+use App\Service\TaskHandler\InformAboutClosingStaleIssuesHandler;
+use App\Service\TaskScheduler;
+use PHPUnit\Framework\TestCase;
+
+class InformAboutClosingStaleIssuesHandlerTest extends TestCase
+{
+    public function testHandleKeepOpen()
+    {
+        $labelApi = $this->getMockBuilder(NullLabelApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIssueLabels', 'lastCommentWasMadeByBot'])
+            ->getMock();
+        $labelApi->expects($this->any())->method('getIssueLabels')->willReturn(['Bug', 'Keep open']);
+
+        $issueApi = $this->getMockBuilder(NullIssueApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['close', 'lastCommentWasMadeByBot'])
+            ->getMock();
+        $issueApi->expects($this->any())->method('lastCommentWasMadeByBot')->willReturn(true);
+        $issueApi->expects($this->never())->method('close');
+
+        $scheduler = $this->getMockBuilder(TaskScheduler::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['runLater'])
+            ->getMock();
+        $scheduler->expects($this->never())->method('runLater');
+
+        $repoProvider = new RepositoryProvider(['carsonbot-playground/symfony' => []]);
+
+        $handler = new InformAboutClosingStaleIssuesHandler($labelApi, $issueApi, $repoProvider, new StaleIssueCommentGenerator(), $scheduler);
+        $handler->handle(new Task('carsonbot-playground/symfony', 4711, Task::ACTION_CLOSE_STALE, new \DateTimeImmutable()));
+    }
+
+    public function testHandleComments()
+    {
+        $labelApi = $this->getMockBuilder(NullLabelApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIssueLabels', 'lastCommentWasMadeByBot'])
+            ->getMock();
+        $labelApi->expects($this->any())->method('getIssueLabels')->willReturn(['Bug']);
+
+        $issueApi = $this->getMockBuilder(NullIssueApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['close', 'lastCommentWasMadeByBot'])
+            ->getMock();
+        $issueApi->expects($this->any())->method('lastCommentWasMadeByBot')->willReturn(false);
+        $issueApi->expects($this->never())->method('close');
+
+        $scheduler = $this->getMockBuilder(TaskScheduler::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['runLater'])
+            ->getMock();
+        $scheduler->expects($this->never())->method('runLater');
+
+        $repoProvider = new RepositoryProvider(['carsonbot-playground/symfony' => []]);
+
+        $handler = new InformAboutClosingStaleIssuesHandler($labelApi, $issueApi, $repoProvider, new StaleIssueCommentGenerator(), $scheduler);
+        $handler->handle(new Task('carsonbot-playground/symfony', 4711, Task::ACTION_CLOSE_STALE, new \DateTimeImmutable()));
+    }
+
+    public function testHandleStale()
+    {
+        $labelApi = $this->getMockBuilder(NullLabelApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIssueLabels'])
+            ->getMock();
+        $labelApi->expects($this->any())->method('getIssueLabels')->willReturn(['Bug']);
+
+        $issueApi = $this->getMockBuilder(NullIssueApi::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['close', 'lastCommentWasMadeByBot'])
+            ->getMock();
+        $issueApi->expects($this->any())->method('lastCommentWasMadeByBot')->willReturn(true);
+        $issueApi->expects($this->never())->method('close');
+
+        $scheduler = $this->getMockBuilder(TaskScheduler::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['runLater'])
+            ->getMock();
+        $scheduler->expects($this->once())->method('runLater');
+
+        $repoProvider = new RepositoryProvider(['carsonbot-playground/symfony' => []]);
+
+        $handler = new InformAboutClosingStaleIssuesHandler($labelApi, $issueApi, $repoProvider, new StaleIssueCommentGenerator(), $scheduler);
+        $handler->handle(new Task('carsonbot-playground/symfony', 4711, Task::ACTION_CLOSE_STALE, new \DateTimeImmutable()));
+    }
+}

--- a/tests/Subscriber/RemoveStaledLabelOnCommentSubscriberTest.php
+++ b/tests/Subscriber/RemoveStaledLabelOnCommentSubscriberTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Subscriber;
+
+use App\Api\Label\NullLabelApi;
+use App\Event\GitHubEvent;
+use App\GitHubEvents;
+use App\Model\Repository;
+use App\Subscriber\RemoveStaledLabelOnCommentSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class RemoveStaledLabelOnCommentSubscriberTest extends TestCase
+{
+    private $subscriber;
+
+    private $repository;
+
+    /**
+     * @var EventDispatcher
+     */
+    private $dispatcher;
+
+    protected function setUp()
+    {
+        $this->subscriber = new RemoveStaledLabelOnCommentSubscriber(new NullLabelApi(), 'carsonbot');
+        $this->repository = new Repository('carsonbot-playground', 'symfony', null);
+
+        $this->dispatcher = new EventDispatcher();
+        $this->dispatcher->addSubscriber($this->subscriber);
+    }
+
+    public function testOnComment()
+    {
+        $event = new GitHubEvent([
+            'issue' => ['number' => 1234, 'labels' => []], 'comment' => ['user' => ['login' => 'nyholm']],
+        ], $this->repository);
+
+        $this->dispatcher->dispatch($event, GitHubEvents::ISSUE_COMMENT);
+
+        $responseData = $event->getResponseData();
+        $this->assertEmpty($responseData);
+    }
+
+    public function testOnCommentOnStale()
+    {
+        $event = new GitHubEvent([
+            'issue' => ['number' => 1234, 'labels' => [['name' => 'Foo'], ['name' => 'Staled']]], 'comment' => ['user' => ['login' => 'nyholm']],
+        ], $this->repository);
+
+        $this->dispatcher->dispatch($event, GitHubEvents::ISSUE_COMMENT);
+
+        $responseData = $event->getResponseData();
+        $this->assertCount(2, $responseData);
+        $this->assertSame(1234, $responseData['issue']);
+        $this->assertSame(true, $responseData['removed_staled_label']);
+    }
+
+    public function testOnBotCommentOnStale()
+    {
+        $event = new GitHubEvent([
+            'issue' => ['number' => 1234, 'labels' => [['name' => 'Foo'], ['name' => 'Staled']]], 'comment' => ['user' => ['login' => 'carsonbot']],
+        ], $this->repository);
+
+        $this->dispatcher->dispatch($event, GitHubEvents::ISSUE_COMMENT);
+
+        $responseData = $event->getResponseData();
+        $this->assertEmpty($responseData);
+    }
+}


### PR DESCRIPTION
This PR adds a `PingStaleIssuesCommand`. It will look for old inactive issues and start a process with them. 
1. Bot will make a comment to encourage activity and add label "Staled". 
2. Bot will make a comment to inform the issue will be closed
3. Bot will close the issue. 
The process can be interrupted with anyone making a comment on the issue or the "Keep open" label is added. 

The exact times between the steps described above is defined as constants in `PingStaleIssuesCommand`.