### PR TITLE
Ignore 404 exceptions when removing label

### DIFF
--- a/src/Api/Label/GithubLabelApi.php
+++ b/src/Api/Label/GithubLabelApi.php
@@ -89,7 +89,7 @@ class GithubLabelApi implements LabelApi
             $this->labelsApi->remove($repository->getVendor(), $repository->getName(), $issueNumber, $label);
         } catch (RuntimeException $e) {
             // We can just ignore 404 exceptions.
-            if ($e->getCode() !== 404) {
+            if (404 !== $e->getCode()) {
                 throw $e;
             }
         }

--- a/src/Api/Label/GithubLabelApi.php
+++ b/src/Api/Label/GithubLabelApi.php
@@ -4,6 +4,7 @@ namespace App\Api\Label;
 
 use App\Model\Repository;
 use Github\Api\Issue\Labels;
+use Github\Exception\RuntimeException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 
@@ -84,12 +85,14 @@ class GithubLabelApi implements LabelApi
             return;
         }
 
-        $this->labelsApi->remove(
-            $repository->getVendor(),
-            $repository->getName(),
-            $issueNumber,
-            $label
-        );
+        try {
+            $this->labelsApi->remove($repository->getVendor(), $repository->getName(), $issueNumber, $label);
+        } catch (RuntimeException $e) {
+            // We can just ignore 404 exceptions.
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
 
         // Update cache if already loaded
         if (isset($this->labelCache[$key])) {


### PR DESCRIPTION
Github throws 404 on us when we trying to remove a label that is not there.. 

We can just ignore that. 