### PR TITLE
Better trim and add a test

### DIFF
--- a/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
+++ b/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
@@ -61,7 +61,7 @@ class AutoUpdateTitleWithLabelSubscriber implements EventSubscriberInterface
         }
 
         // Add back labels
-        $prTitle = trim($prPrefix.' '.$prTitle);
+        $prTitle = trim($prPrefix.' '.trim($prTitle));
         if ($originalTitle === $prTitle) {
             return;
         }

--- a/tests/Subscriber/AutoUpdateTitleWithLabelSubscriberTest.php
+++ b/tests/Subscriber/AutoUpdateTitleWithLabelSubscriberTest.php
@@ -42,7 +42,7 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
         $this->dispatcher->addSubscriber($this->subscriber);
     }
 
-    public function testOnPullRequestOpen()
+    public function testOnPullRequestLabeled()
     {
         $event = new GitHubEvent([
             'action' => 'labeled',
@@ -62,5 +62,24 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
         $this->assertCount(2, $responseData);
         $this->assertSame(1234, $responseData['pull_request']);
         $this->assertSame('[Console][FrameworkBundle] [bar] Foo', $responseData['new_title']);
+    }
+
+    public function testOnPullRequestLabeledWithExisting()
+    {
+        $event = new GitHubEvent([
+            'action' => 'labeled',
+            'number' => 1234,
+            'pull_request' => [
+                'title' => '[Messenger] Fix JSON',
+                'labels' => [
+                    ['name' => 'Status: Needs Review', 'color' => 'abcabc'],
+                    ['name' => 'Messenger', 'color' => 'dddddd'],
+                ],
+            ],
+        ], $this->repository);
+
+        $this->dispatcher->dispatch($event, GitHubEvents::PULL_REQUEST);
+        $responseData = $event->getResponseData();
+        $this->assertEmpty($responseData);
     }
 }


### PR DESCRIPTION
My second attempt to fix the issue in #97. 

The fix in #112 was only fixing part of the problem.

--------

This PR fix the issue when a label is `[Component]&nbsp;Foo`. We trying to change that to `[Component]&nbsp;&nbsp;Foo` (double space). 
Github is nice enough to remove double spaces, but that means that we update the title all the time...