### PR TITLE
Run a search to verify that this is the first PR of the user

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -69,6 +69,10 @@ services:
         factory: ['@Github\Client', api]
         arguments: [pullRequest]
 
+    Github\Api\Repo:
+        factory: ['@Github\Client', api]
+        arguments: [repo]
+
     Github\Api\Search:
         factory: ['@Github\Client', api]
         arguments: [search]
@@ -87,6 +91,7 @@ services:
     App\Api\Issue\IssueApi: '@App\Api\Issue\GithubIssueApi'
     App\Api\Label\LabelApi: '@App\Api\Label\GithubLabelApi'
     App\Api\Milestone\MilestoneApi: '@App\Api\Milestone\GithubMilestoneApi'
+    App\Api\PullRequest\PullRequestApi: '@App\Api\PullRequest\GithubPullRequestApi'
     App\Api\Status\StatusApi: '@App\Api\Status\GitHubStatusApi'
 
     App\Service\RepositoryProvider:

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -6,4 +6,5 @@ services:
     App\Api\Issue\IssueApi: '@App\Api\Issue\NullIssueApi'
     App\Api\Label\LabelApi: '@App\Api\Label\StaticLabelApi'
     App\Api\Milestone\MilestoneApi: '@App\Api\Milestone\StaticMilestoneApi'
+    App\Api\PullRequest\PullRequestApi: '@App\Api\PullRequest\GithubPullRequestApi'
     App\Api\Status\StatusApi: '@App\Api\Status\NullStatusApi'

--- a/src/Api/PullRequest/GithubPullRequestApi.php
+++ b/src/Api/PullRequest/GithubPullRequestApi.php
@@ -5,6 +5,7 @@ namespace App\Api\PullRequest;
 use App\Model\Repository;
 use Github\Api\PullRequest;
 use Github\Api\Repo;
+use Github\Api\Search;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -15,14 +16,16 @@ class GithubPullRequestApi implements PullRequestApi
      * @var Repo
      */
     private $github;
-    private $botUsername;
     private $pullRequest;
+    private $search;
+    private $botUsername;
 
-    public function __construct(Repo $github, PullRequest $pullRequest, string $botUsername)
+    public function __construct(Repo $github, PullRequest $pullRequest, Search $search, string $botUsername)
     {
         $this->github = $github;
-        $this->botUsername = $botUsername;
         $this->pullRequest = $pullRequest;
+        $this->search = $search;
+        $this->botUsername = $botUsername;
     }
 
     public function show(Repository $repository, $number): array
@@ -40,5 +43,12 @@ class GithubPullRequestApi implements PullRequestApi
             'pull_request_number' => $number,
             'type' => $type,
         ]);
+    }
+
+    public function getAuthorCount(Repository $repository, string $author): int
+    {
+        $result = $this->search->issues(sprintf('is:pr repo:%s author:%s', $repository->getFullName(), $author));
+
+        return $result['total_count'];
     }
 }

--- a/src/Api/PullRequest/NullPullRequestApi.php
+++ b/src/Api/PullRequest/NullPullRequestApi.php
@@ -19,4 +19,9 @@ class NullPullRequestApi implements PullRequestApi
     public function findReviewer(Repository $repository, $number, string $type)
     {
     }
+
+    public function getAuthorCount(Repository $repository, string $author): int
+    {
+        return 1;
+    }
 }

--- a/src/Api/PullRequest/PullRequestApi.php
+++ b/src/Api/PullRequest/PullRequestApi.php
@@ -17,4 +17,6 @@ interface PullRequestApi
     public function show(Repository $repository, $number): array;
 
     public function findReviewer(Repository $repository, $number, string $type);
+
+    public function getAuthorCount(Repository $repository, string $author): int;
 }


### PR DESCRIPTION
This will make sure that we don't send a "welcome message" twice when the user's first PR was not merged. 