### PR TITLE
Make sure we consider case when updating title

### DIFF
--- a/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
+++ b/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
@@ -50,11 +50,11 @@ class AutoUpdateTitleWithLabelSubscriber implements EventSubscriberInterface
             if ('dddddd' === strtolower($label['color'])) {
                 $validLabels[] = $label['name'];
                 // Remove label name from title
-                $prTitle = str_replace('['.$label['name'].']', '', $prTitle);
+                $prTitle = str_ireplace('['.$label['name'].']', '', $prTitle);
 
                 // Remove label aliases from title
                 foreach ($this->labelExtractor->getAliasesForLabel($label['name']) as $alias) {
-                    $prTitle = str_replace('['.$alias.']', '', $prTitle);
+                    $prTitle = str_ireplace('['.$alias.']', '', $prTitle);
                 }
             }
         }

--- a/tests/Subscriber/AutoUpdateTitleWithLabelSubscriberTest.php
+++ b/tests/Subscriber/AutoUpdateTitleWithLabelSubscriberTest.php
@@ -65,6 +65,27 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
         $this->assertSame('[Console][FrameworkBundle] [bar] Foo', $responseData['new_title']);
     }
 
+    public function testOnPullRequestLabeledCaseInsensitive()
+    {
+        $event = new GitHubEvent([
+            'action' => 'labeled',
+            'number' => 1234,
+            'pull_request' => [
+                'title' => '[PHPunitbridge] Foo',
+                'labels' => [
+                    ['name' => 'PhpUnitBridge', 'color' => 'dddddd'],
+                ],
+            ],
+        ], $this->repository);
+
+        $this->dispatcher->dispatch($event, GitHubEvents::PULL_REQUEST);
+        $responseData = $event->getResponseData();
+
+        $this->assertCount(2, $responseData);
+        $this->assertSame(1234, $responseData['pull_request']);
+        $this->assertSame('[PhpUnitBridge] Foo', $responseData['new_title']);
+    }
+
     public function testOnPullRequestLabeledWithExisting()
     {
         $event = new GitHubEvent([


### PR DESCRIPTION
Just a small bugfix. To avoid names like: 


```
[TwigBundle] [twigbundle] Fixed syntax error in config
```


#SymfonyHackday