### PR TITLE
Disable preloading

### DIFF
--- a/.symfony.cloud.yaml
+++ b/.symfony.cloud.yaml
@@ -20,9 +20,9 @@ web:
 
 disk: 2048
 
-variables:
-    php:
-        opcache.preload: /app/config/preload.php
+#variables:
+#    php:
+#        opcache.preload: /app/config/preload.php
 
 mounts:
     '/var': { source: local, source_path: var }


### PR DESCRIPTION
Im looking at Carsonbot’s php logs. I see a lot of `zend_mm_heap corrupted`. It seams to be related to bug in php extensions or some kind miss-manage of memory. 

However, we dont have any extra extensions...

I saw this [php bug](https://bugs.php.net/bug.php?id=78995), a maintainer suggest that this warning could be ignored but they didn't give any explanation why or how. 

I want to disable preloading to see if the error is related. 