### PR TITLE
If there is a comment on a closed issue, then dont remove "stalled" label

### DIFF
--- a/src/Subscriber/RemoveStalledLabelOnCommentSubscriber.php
+++ b/src/Subscriber/RemoveStalledLabelOnCommentSubscriber.php
@@ -34,6 +34,11 @@ class RemoveStalledLabelOnCommentSubscriber implements EventSubscriberInterface
             return;
         }
 
+        // If not open, then do nothing
+        if ('open' !== $data['issue']['state']) {
+            return;
+        }
+
         $removed = false;
         $issueNumber = $data['issue']['number'];
         foreach ($data['issue']['labels'] as $label) {

--- a/tests/Subscriber/RemoveStalledLabelOnCommentSubscriberTest.php
+++ b/tests/Subscriber/RemoveStalledLabelOnCommentSubscriberTest.php
@@ -35,7 +35,7 @@ class RemoveStalledLabelOnCommentSubscriberTest extends TestCase
     public function testOnComment()
     {
         $event = new GitHubEvent([
-            'issue' => ['number' => 1234, 'labels' => []], 'comment' => ['user' => ['login' => 'nyholm']],
+            'issue' => ['number' => 1234, 'state' => 'open', 'labels' => []], 'comment' => ['user' => ['login' => 'nyholm']],
         ], $this->repository);
 
         $this->dispatcher->dispatch($event, GitHubEvents::ISSUE_COMMENT);
@@ -47,7 +47,7 @@ class RemoveStalledLabelOnCommentSubscriberTest extends TestCase
     public function testOnCommentOnStale()
     {
         $event = new GitHubEvent([
-            'issue' => ['number' => 1234, 'labels' => [['name' => 'Foo'], ['name' => 'Stalled']]], 'comment' => ['user' => ['login' => 'nyholm']],
+            'issue' => ['number' => 1234, 'state' => 'open', 'labels' => [['name' => 'Foo'], ['name' => 'Stalled']]], 'comment' => ['user' => ['login' => 'nyholm']],
         ], $this->repository);
 
         $this->dispatcher->dispatch($event, GitHubEvents::ISSUE_COMMENT);
@@ -61,7 +61,19 @@ class RemoveStalledLabelOnCommentSubscriberTest extends TestCase
     public function testOnBotCommentOnStale()
     {
         $event = new GitHubEvent([
-            'issue' => ['number' => 1234, 'labels' => [['name' => 'Foo'], ['name' => 'Stalled']]], 'comment' => ['user' => ['login' => 'carsonbot']],
+            'issue' => ['number' => 1234, 'state' => 'open', 'labels' => [['name' => 'Foo'], ['name' => 'Stalled']]], 'comment' => ['user' => ['login' => 'carsonbot']],
+        ], $this->repository);
+
+        $this->dispatcher->dispatch($event, GitHubEvents::ISSUE_COMMENT);
+
+        $responseData = $event->getResponseData();
+        $this->assertEmpty($responseData);
+    }
+
+    public function testCommentOnClosed()
+    {
+        $event = new GitHubEvent([
+            'issue' => ['number' => 1234, 'state' => 'closed', 'labels' => [['name' => 'Foo'], ['name' => 'Stalled']]], 'comment' => ['user' => ['login' => 'nyholm']],
         ], $this->repository);
 
         $this->dispatcher->dispatch($event, GitHubEvents::ISSUE_COMMENT);


### PR DESCRIPTION
This is just nice to have

Example: https://github.com/symfony/symfony/issues/32597