### PR TITLE
Reduce the time before the first ping

### DIFF
--- a/.symfony.cloud.yaml
+++ b/.symfony.cloud.yaml
@@ -44,11 +44,11 @@ crons:
 
     stale_issues_symfony:
         spec: '58 12 * * *'
-        cmd: croncape bin/console app:issue:ping-stale symfony/symfony
+        cmd: croncape bin/console app:issue:ping-stale symfony/symfony --not-updated-for 6months
 
     stale_issues_docs:
         spec: '48 12 * * *'
-        cmd: croncape bin/console app:issue:ping-stale symfony/symfony-docs
+        cmd: croncape bin/console app:issue:ping-stale symfony/symfony-docs --not-updated-for 12months
 
 relationships:
     database: "mydatabase:postgresql"

--- a/src/Command/PingStaleIssuesCommand.php
+++ b/src/Command/PingStaleIssuesCommand.php
@@ -61,7 +61,9 @@ class PingStaleIssuesCommand extends Command
             return 1;
         }
 
-        $notUpdatedAfter = new \DateTimeImmutable((string) $input->getOption('not-updated-for'));
+        /** @var string $timeString */
+        $timeString = $input->getOption('not-updated-for');
+        $notUpdatedAfter = new \DateTimeImmutable($timeString);
         $issues = $this->issueApi->findStaleIssues($repository, $notUpdatedAfter);
 
         if ($input->getOption('dry-run')) {

--- a/src/Command/PingStaleIssuesCommand.php
+++ b/src/Command/PingStaleIssuesCommand.php
@@ -63,7 +63,7 @@ class PingStaleIssuesCommand extends Command
 
         /** @var string $timeString */
         $timeString = $input->getOption('not-updated-for');
-        $notUpdatedAfter = new \DateTimeImmutable($timeString);
+        $notUpdatedAfter = new \DateTimeImmutable('-'.ltrim($timeString, '-'));
         $issues = $this->issueApi->findStaleIssues($repository, $notUpdatedAfter);
 
         if ($input->getOption('dry-run')) {

--- a/src/Command/PingStaleIssuesCommand.php
+++ b/src/Command/PingStaleIssuesCommand.php
@@ -22,7 +22,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class PingStaleIssuesCommand extends Command
 {
-    public const STALE_IF_NOT_UPDATED_SINCE = '-3months';
     public const MESSAGE_TWO_AFTER = '+2weeks';
     public const MESSAGE_THREE_AND_CLOSE_AFTER = '+2weeks';
 
@@ -47,6 +46,7 @@ class PingStaleIssuesCommand extends Command
     protected function configure()
     {
         $this->addArgument('repository', InputArgument::REQUIRED, 'The full name to the repository, eg symfony/symfony-docs');
+        $this->addOption('not-updated-for', null, InputOption::VALUE_REQUIRED, 'A string representing a time period to for how long the issue has been stalled.', '12months');
         $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do a test search without making any comments or changes');
     }
 
@@ -61,7 +61,7 @@ class PingStaleIssuesCommand extends Command
             return 1;
         }
 
-        $notUpdatedAfter = new \DateTimeImmutable(self::STALE_IF_NOT_UPDATED_SINCE);
+        $notUpdatedAfter = new \DateTimeImmutable((string) $input->getOption('not-updated-for'));
         $issues = $this->issueApi->findStaleIssues($repository, $notUpdatedAfter);
 
         if ($input->getOption('dry-run')) {

--- a/src/Command/PingStaleIssuesCommand.php
+++ b/src/Command/PingStaleIssuesCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class PingStaleIssuesCommand extends Command
 {
-    public const STALE_IF_NOT_UPDATED_SINCE = '-12months';
+    public const STALE_IF_NOT_UPDATED_SINCE = '-3months';
     public const MESSAGE_TWO_AFTER = '+2weeks';
     public const MESSAGE_THREE_AND_CLOSE_AFTER = '+2weeks';
 


### PR DESCRIPTION
We've tried 12 months. From what I've seen there have only been positive responses. A bunch of issues have been closed but nobody was upset. 

People also understood that they should make a comment to show that the issue is still relevant and maintainer have added the "Keep open" label on some issues. 

Even I have been notified about issues I've forgotten. =)

The original request for this feature suggested 3 months before the first ping, we decided to try out this feature on super old issues first. I think the try out period has proven to be successful. 