### PR TITLE
Disable suggesting reviewers in docs repository

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -24,7 +24,6 @@ parameters:
                 - 'App\Subscriber\StatusChangeByReviewSubscriber'
                 - 'App\Subscriber\NeedsReviewNewPRSubscriber'
                 - 'App\Subscriber\BugLabelNewIssueSubscriber'
-                - 'App\Subscriber\FindReviewerSubscriber'
                 - 'App\Subscriber\AutoLabelFromContentSubscriber'
                 - 'App\Subscriber\UnsupportedBranchSubscriber'
                 - 'subscriber.symfony_docs.milestone'


### PR DESCRIPTION
I shortly discussed this with the doc team, and I think this feature is not applicable to the docs repo:

* It's very common for us to not respond to a PR within 20 hours
* Many documents are created by us, the community mostly fixes small stuff. Also, 1 document contains many features, editing a line somewhere in the document doesn't indicate you're the expert for other features in the document. E.g. in https://github.com/symfony/symfony-docs/pull/14850, the pinged user modified the example README: https://github.com/symfony/symfony-docs/commit/6e8d39389b5912e29bbcebcfaec80be42e977118