### PR TITLE
Fix: Map translator to Translation

### DIFF
--- a/src/Api/Label/StaticLabelApi.php
+++ b/src/Api/Label/StaticLabelApi.php
@@ -24,7 +24,7 @@ class StaticLabelApi extends NullLabelApi
             'OptionsResolver', 'PhpUnitBridge', 'Process', 'PropertyAccess',
             'PropertyInfo', 'ProxyManagerBridge', 'Routing', 'Security',
             'SecurityBundle', 'Serializer', 'Stopwatch', 'String', 'Templating',
-            'Translator', 'TwigBridge', 'TwigBundle', 'Uid', 'Validator', 'VarDumper',
+            'Translation', 'TwigBridge', 'TwigBundle', 'Uid', 'Validator', 'VarDumper',
             'VarExporter', 'WebLink', 'WebProfilerBundle', 'WebServerBundle', 'Workflow',
             'Yaml',
         ];

--- a/src/Service/LabelNameExtractor.php
+++ b/src/Service/LabelNameExtractor.php
@@ -31,7 +31,7 @@ class LabelNameExtractor
         'fwb' => 'FrameworkBundle',
         'profiler' => 'WebProfilerBundle',
         'router' => 'Routing',
-        'translation' => 'Translator',
+        'translator' => 'Translation',
         'wdt' => 'WebProfilerBundle',
     ];
 


### PR DESCRIPTION
This pull request

* [x] uses `Translation` instead of `Translator` as component name and maps `translator` to `Translation`

💁‍♂️ After opening pull requests in `symfony/symfony`, I noticed that @carsonbot renames occurrences of **Translation** to **Translator** in pull request titles, and also adds a **Translator** label.

A **Translator** component does not exist. There is, however, a component that is called `Translation`.

See

- https://github.com/symfony/translation
- https://symfony.com/components/Translation

For an example, see https://github.com/symfony/symfony/pull/40180.

![CleanShot 2021-02-14 at 13 11 43](https://user-images.githubusercontent.com/605483/107876435-42e7ce80-6ec6-11eb-9805-70658db0e55d.png)
