### PR TITLE
Fix space in auto title

### DIFF
--- a/tests/Api/Label/GithubLabelApiTest.php
+++ b/tests/Api/Label/GithubLabelApiTest.php
@@ -78,7 +78,7 @@ class GithubLabelApiTest extends TestCase
 
         $this->backendApi->expects($this->once())
             ->method('add')
-            ->with(self::USER_NAME, self::REPO_NAME, 1234, 'a');
+            ->with(self::USER_NAME, self::REPO_NAME, 1234, ['a']);
 
         $this->api->addIssueLabel(1234, 'a', $this->repository);
     }
@@ -96,7 +96,7 @@ class GithubLabelApiTest extends TestCase
 
         $this->backendApi->expects($this->once())
             ->method('add')
-            ->with(self::USER_NAME, self::REPO_NAME, 1234, 'd');
+            ->with(self::USER_NAME, self::REPO_NAME, 1234, ['d']);
 
         $this->assertSame(['a', 'b', 'c'], $this->api->getIssueLabels(1234, $this->repository));
 


### PR DESCRIPTION
This will fix #161. 

@wouterj, this was interesting. 

What happen is: 
1. PR is posted it as `[RateLimiter][Security] ...`
2. Carson parses the title and adds label "RateLimiter", then "Security"
3. Github sends a "label was updated ping" about RateLimiter
4. Carson correctly title to `[RateLimiter] [Security] ...` because " Security was not marked as a label yet. 
5. Github sends a "label was updated ping" about Security
6. Carson will update the title again, and correctly set it to `[RateLimiter][Security] ...`

However, It is a race condition... if 3 and 5 is reversed, then you experience the wrong title.

The easy fix is to update the two labels at the same time, which is what I do in this PR. 