### PR TITLE
Bugfix with auto label

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "symfony/symfony": "*"
     },
     "require-dev": {
+        "happyr/service-mocking": "^0.1.3",
         "symfony/browser-kit": "^5.1",
         "symfony/phpunit-bridge": "^5.1",
         "symfony/web-profiler-bundle": "^5.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1a32e1c772f435c927ba591627a0ffc",
+    "content-hash": "97f19e377cd042ac8060778af6d21008",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -1410,6 +1410,88 @@
             "time": "2020-07-30T16:57:33+00:00"
         },
         {
+            "name": "friendsofphp/proxy-manager-lts",
+            "version": "v1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/proxy-manager-lts.git",
+                "reference": "121af47c9aee9c03031bdeca3fac0540f59aa5c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/proxy-manager-lts/zipball/121af47c9aee9c03031bdeca3fac0540f59aa5c3",
+                "reference": "121af47c9aee9c03031bdeca3fac0540f59aa5c3",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-code": "~3.4.1|^4.0",
+                "php": ">=7.1",
+                "symfony/filesystem": "^4.4.17|^5.0"
+            },
+            "conflict": {
+                "laminas/laminas-stdlib": "<3.2.1",
+                "zendframework/zend-stdlib": "<3.2.1"
+            },
+            "replace": {
+                "ocramius/proxy-manager": "^2.1"
+            },
+            "require-dev": {
+                "ext-phar": "*",
+                "symfony/phpunit-bridge": "^5.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "ocramius/proxy-manager",
+                    "url": "https://github.com/Ocramius/ProxyManager"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ProxyManager\\": "src/ProxyManager"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.io/"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                }
+            ],
+            "description": "Adding support for a wider range of PHP versions to ocramius/proxy-manager",
+            "homepage": "https://github.com/FriendsOfPHP/proxy-manager-lts",
+            "keywords": [
+                "aop",
+                "lazy loading",
+                "proxy",
+                "proxy pattern",
+                "service proxies"
+            ],
+            "support": {
+                "issues": "https://github.com/FriendsOfPHP/proxy-manager-lts/issues",
+                "source": "https://github.com/FriendsOfPHP/proxy-manager-lts/tree/v1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ocramius/proxy-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-14T21:52:44+00:00"
+        },
+        {
             "name": "incenteev/composer-parameter-handler",
             "version": "v2.1.4",
             "source": {
@@ -1534,6 +1616,209 @@
                 }
             ],
             "time": "2020-11-14T17:07:32+00:00"
+        },
+        {
+            "name": "laminas/laminas-code",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-code.git",
+                "reference": "28a6d70ea8b8bca687d7163300e611ae33baf82a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/28a6d70ea8b8bca687d7163300e611ae33baf82a",
+                "reference": "28a6d70ea8b8bca687d7163300e611ae33baf82a",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-eventmanager": "^3.3",
+                "php": "^7.4 || ~8.0.0"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.9.0"
+            },
+            "replace": {
+                "zendframework/zend-code": "self.version"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.10.4",
+                "ext-phar": "*",
+                "laminas/laminas-coding-standard": "^2.1.4",
+                "laminas/laminas-stdlib": "^3.3.0",
+                "phpunit/phpunit": "^9.4.2",
+                "psalm/plugin-phpunit": "^0.14.0",
+                "vimeo/psalm": "^4.3.1"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "laminas/laminas-stdlib": "Laminas\\Stdlib component",
+                "laminas/laminas-zendframework-bridge": "A bridge with Zend Framework"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Extensions to the PHP Reflection API, static code scanning, and code generation",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "code",
+                "laminas",
+                "laminasframework"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-code/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-code/issues",
+                "rss": "https://github.com/laminas/laminas-code/releases.atom",
+                "source": "https://github.com/laminas/laminas-code"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-12-30T16:16:14+00:00"
+        },
+        {
+            "name": "laminas/laminas-eventmanager",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-eventmanager.git",
+                "reference": "1940ccf30e058b2fd66f5a9d696f1b5e0027b082"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/1940ccf30e058b2fd66f5a9d696f1b5e0027b082",
+                "reference": "1940ccf30e058b2fd66f5a9d696f1b5e0027b082",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "replace": {
+                "zendframework/zend-eventmanager": "^3.2.1"
+            },
+            "require-dev": {
+                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0",
+                "phpbench/phpbench": "^0.17.1",
+                "phpunit/phpunit": "^8.5.8"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1, to use the lazy listeners feature",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev",
+                    "dev-develop": "3.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-eventmanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-eventmanager/issues",
+                "rss": "https://github.com/laminas/laminas-eventmanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-eventmanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-08-25T11:10:44+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "6ede70583e101030bcace4dcddd648f760ddf642"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6ede70583e101030bcace4dcddd648f760ddf642",
+                "reference": "6ede70583e101030bcace4dcddd648f760ddf642",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "support": {
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
+                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
+                "source": "https://github.com/laminas/laminas-zendframework-bridge"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-09-14T14:23:00+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1702,76 +1987,6 @@
                 }
             ],
             "time": "2020-11-14T17:35:34+00:00"
-        },
-        {
-            "name": "ocramius/proxy-manager",
-            "version": "2.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Ocramius/ProxyManager.git",
-                "reference": "4d154742e31c35137d5374c998e8f86b54db2e2f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/4d154742e31c35137d5374c998e8f86b54db2e2f",
-                "reference": "4d154742e31c35137d5374c998e8f86b54db2e2f",
-                "shasum": ""
-            },
-            "require": {
-                "ocramius/package-versions": "^1.1.3",
-                "php": "^7.2.0",
-                "zendframework/zend-code": "^3.3.0"
-            },
-            "require-dev": {
-                "couscous/couscous": "^1.6.1",
-                "ext-phar": "*",
-                "humbug/humbug": "1.0.0-RC.0@RC",
-                "nikic/php-parser": "^3.1.1",
-                "padraic/phpunit-accelerator": "dev-master@DEV",
-                "phpbench/phpbench": "^0.12.2",
-                "phpstan/phpstan": "dev-master#856eb10a81c1d27c701a83f167dc870fd8f4236a as 0.9.999",
-                "phpstan/phpstan-phpunit": "dev-master#5629c0a1f4a9c417cb1077cf6693ad9753895761",
-                "phpunit/phpunit": "^6.4.3",
-                "squizlabs/php_codesniffer": "^2.9.1"
-            },
-            "suggest": {
-                "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
-                "zendframework/zend-json": "To have the JsonRpc adapter (Remote Object feature)",
-                "zendframework/zend-soap": "To have the Soap adapter (Remote Object feature)",
-                "zendframework/zend-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "ProxyManager\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.io/"
-                }
-            ],
-            "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
-            "homepage": "https://github.com/Ocramius/ProxyManager",
-            "keywords": [
-                "aop",
-                "lazy loading",
-                "proxy",
-                "proxy pattern",
-                "service proxies"
-            ],
-            "time": "2019-08-10T08:37:15+00:00"
         },
         {
             "name": "php-http/cache-plugin",
@@ -6079,122 +6294,68 @@
                 }
             ],
             "time": "2020-10-27T19:28:23+00:00"
-        },
-        {
-            "name": "zendframework/zend-code",
-            "version": "3.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-code.git",
-                "reference": "268040548f92c2bfcba164421c1add2ba43abaaa"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/268040548f92c2bfcba164421c1add2ba43abaaa",
-                "reference": "268040548f92c2bfcba164421c1add2ba43abaaa",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1",
-                "zendframework/zend-eventmanager": "^2.6 || ^3.0"
-            },
-            "conflict": {
-                "phpspec/prophecy": "<1.9.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^1.7",
-                "ext-phar": "*",
-                "phpunit/phpunit": "^7.5.16 || ^8.4",
-                "zendframework/zend-coding-standard": "^1.0",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
-            },
-            "suggest": {
-                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
-                "zendframework/zend-stdlib": "Zend\\Stdlib component"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4.x-dev",
-                    "dev-develop": "3.5.x-dev",
-                    "dev-dev-4.0": "4.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Code\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Extensions to the PHP Reflection API, static code scanning, and code generation",
-            "keywords": [
-                "ZendFramework",
-                "code",
-                "zf"
-            ],
-            "abandoned": "laminas/laminas-code",
-            "time": "2019-12-10T19:21:15+00:00"
-        },
-        {
-            "name": "zendframework/zend-eventmanager",
-            "version": "3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-eventmanager.git",
-                "reference": "a5e2583a211f73604691586b8406ff7296a946dd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/a5e2583a211f73604691586b8406ff7296a946dd",
-                "reference": "a5e2583a211f73604691586b8406ff7296a946dd",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "athletic/athletic": "^0.1",
-                "container-interop/container-interop": "^1.1.0",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
-                "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
-            },
-            "suggest": {
-                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
-                "zendframework/zend-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2-dev",
-                    "dev-develop": "3.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\EventManager\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Trigger and listen to events within a PHP application",
-            "homepage": "https://github.com/zendframework/zend-eventmanager",
-            "keywords": [
-                "event",
-                "eventmanager",
-                "events",
-                "zf2"
-            ],
-            "abandoned": "laminas/laminas-eventmanager",
-            "time": "2018-04-25T15:33:34+00:00"
         }
     ],
     "packages-dev": [
+        {
+            "name": "happyr/service-mocking",
+            "version": "0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Happyr/service-mocking.git",
+                "reference": "34715734f89a0c5e494d9928ed36be2683f07482"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Happyr/service-mocking/zipball/34715734f89a0c5e494d9928ed36be2683f07482",
+                "reference": "34715734f89a0c5e494d9928ed36be2683f07482",
+                "shasum": ""
+            },
+            "require": {
+                "friendsofphp/proxy-manager-lts": "^1.0",
+                "php": ">=7.2",
+                "symfony/config": "^4.4 || ^5.1",
+                "symfony/dependency-injection": "^4.4 || ^5.1",
+                "symfony/http-kernel": "^4.4 || ^5.1"
+            },
+            "require-dev": {
+                "nyholm/symfony-bundle-test": "^1.6",
+                "symfony/phpunit-bridge": "^4.4 || ^5.2"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Happyr\\ServiceMocking\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                }
+            ],
+            "description": "Make it easy to mock services in a built container",
+            "keywords": [
+                "mock",
+                "symfony",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Happyr/service-mocking/issues",
+                "source": "https://github.com/Happyr/service-mocking/tree/0.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-26T11:34:18+00:00"
+        },
         {
             "name": "symfony/browser-kit",
             "version": "v5.1.8",
@@ -6517,5 +6678,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -9,4 +9,5 @@ return [
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
+    Happyr\ServiceMocking\HappyrServiceMockingBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/config/packages/test/happyr_service_mocking.yaml
+++ b/config/packages/test/happyr_service_mocking.yaml
@@ -1,0 +1,3 @@
+happyr_service_mocking:
+    services:
+        - 'App\Api\PullRequest\PullRequestApi'

--- a/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
+++ b/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
@@ -51,7 +51,7 @@ class AutoUpdateTitleWithLabelSubscriber implements EventSubscriberInterface
         $lock = $this->lockFactory->createLock($repository->getFullName().'#'.$number);
         $lock->acquire(true); // blocking. Lock will be released at __destruct
 
-        // Fetch the current PR just to make sure it has not changed
+        // Fetch the current PR just to make sure we are working with all available information
         $githubPullRequest = $this->pullRequestApi->show($repository, $number);
         $originalTitle = $prTitle = trim($githubPullRequest['title']);
         $validLabels = [];

--- a/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
+++ b/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
@@ -53,7 +53,7 @@ class AutoUpdateTitleWithLabelSubscriber implements EventSubscriberInterface
 
         // Fetch the current PR just to make sure we are working with all available information
         $githubPullRequest = $this->pullRequestApi->show($repository, $number);
-        $originalTitle = $prTitle = trim($githubPullRequest['title']);
+        $originalTitle = $prTitle = trim($githubPullRequest['title'] ?? '');
         $validLabels = [];
 
         foreach ($githubPullRequest['labels'] ?? [] as $label) {

--- a/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
+++ b/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
@@ -47,6 +47,7 @@ class AutoUpdateTitleWithLabelSubscriber implements EventSubscriberInterface
         $repository = $event->getRepository();
         $number = $data['number'];
 
+        sleep(1); // Wait for github API to be updated
         $lock = $this->lockFactory->createLock($repository->getFullName().'#'.$number);
         $lock->acquire(true); // blocking. Lock will be released at __destruct
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -81,6 +81,12 @@
     "doctrine/sql-formatter": {
         "version": "1.1.1"
     },
+    "friendsofphp/proxy-manager-lts": {
+        "version": "v1.0.3"
+    },
+    "happyr/service-mocking": {
+        "version": "0.1.3"
+    },
     "incenteev/composer-parameter-handler": {
         "version": "v2.1.4"
     },
@@ -96,6 +102,15 @@
             "config/packages/github_api.yaml"
         ]
     },
+    "laminas/laminas-code": {
+        "version": "4.0.0"
+    },
+    "laminas/laminas-eventmanager": {
+        "version": "3.3.0"
+    },
+    "laminas/laminas-zendframework-bridge": {
+        "version": "1.1.1"
+    },
     "monolog/monolog": {
         "version": "2.1.0"
     },
@@ -110,9 +125,6 @@
         "files": [
             "config/packages/nyholm_psr7.yaml"
         ]
-    },
-    "ocramius/proxy-manager": {
-        "version": "2.2.3"
     },
     "php": {
         "version": "7.4"
@@ -405,11 +417,5 @@
     },
     "twig/twig": {
         "version": "v3.0.3"
-    },
-    "zendframework/zend-code": {
-        "version": "3.4.1"
-    },
-    "zendframework/zend-eventmanager": {
-        "version": "3.2.1"
     }
 }

--- a/tests/Controller/WebhookControllerTest.php
+++ b/tests/Controller/WebhookControllerTest.php
@@ -2,12 +2,16 @@
 
 namespace App\Tests\Controller;
 
+use App\Api\PullRequest\PullRequestApi;
 use App\Api\Status\StatusApi;
 use App\Service\RepositoryProvider;
+use Happyr\ServiceMocking\ServiceMock;
+use Happyr\ServiceMocking\Test\RestoreServiceContainer;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class WebhookControllerTest extends WebTestCase
 {
+    use RestoreServiceContainer;
     private $client;
 
     public function setup()
@@ -19,6 +23,17 @@ class WebhookControllerTest extends WebTestCase
         $this->client = $this->createClient();
         $repository = self::$container->get(RepositoryProvider::class);
         $statusApi = self::$container->get(StatusApi::class);
+        $pullRequestApi = self::$container->get(PullRequestApi::class);
+
+        ServiceMock::all($pullRequestApi, 'show', function ($repository, $id) {
+            if ($id !== 4711) {
+                return [];
+            }
+
+            return ['title'=>'Readme update', 'labels' => [
+                ['name' => 'Messenger', 'color' => 'dddddd'],
+            ]];
+        });
 
         // the labels need to be off this issue for one test to pass
         $statusApi->setIssueStatus(2, null, $repository->getRepository('carsonbot-playground/symfony'));
@@ -67,7 +82,7 @@ class WebhookControllerTest extends WebTestCase
             'On pull request labeled' => [
                 'pull_request',
                 'pull_request.labeled.json',
-                ['pull_request' => 3, 'new_title' => '[Messenger] Readme update'],
+                ['pull_request' => 4711, 'new_title' => '[Messenger] Readme update'],
             ],
             'On pull request opened with target branch' => [
                 'pull_request',

--- a/tests/Controller/WebhookControllerTest.php
+++ b/tests/Controller/WebhookControllerTest.php
@@ -26,11 +26,11 @@ class WebhookControllerTest extends WebTestCase
         $pullRequestApi = self::$container->get(PullRequestApi::class);
 
         ServiceMock::all($pullRequestApi, 'show', function ($repository, $id) {
-            if ($id !== 4711) {
+            if (4711 !== $id) {
                 return [];
             }
 
-            return ['title'=>'Readme update', 'labels' => [
+            return ['title' => 'Readme update', 'labels' => [
                 ['name' => 'Messenger', 'color' => 'dddddd'],
             ]];
         });

--- a/tests/Subscriber/AutoUpdateTitleWithLabelSubscriberTest.php
+++ b/tests/Subscriber/AutoUpdateTitleWithLabelSubscriberTest.php
@@ -45,7 +45,7 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
 
     public function testOnPullRequestLabeled()
     {
-        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request'=>[]], $this->repository);
+        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request' => []], $this->repository);
         $this->pullRequestApi->method('show')->willReturn([
             'title' => '[fwb][bar] Foo',
             'labels' => [
@@ -64,7 +64,7 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
 
     public function testOnPullRequestLabeledCaseInsensitive()
     {
-        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request'=>[]], $this->repository);
+        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request' => []], $this->repository);
         $this->pullRequestApi->method('show')->willReturn([
             'title' => '[PHPunitbridge] Foo',
             'labels' => [
@@ -82,7 +82,7 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
 
     public function testOnPullRequestLabeledWithExisting()
     {
-        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request'=>[]], $this->repository);
+        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request' => []], $this->repository);
         $this->pullRequestApi->method('show')->willReturn([
                 'title' => '[Messenger] Fix JSON',
                 'labels' => [
@@ -98,7 +98,7 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
 
     public function testRemoveLabel()
     {
-        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request'=>[]], $this->repository);
+        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request' => []], $this->repository);
         $this->pullRequestApi->method('show')->willReturn([
                 'title' => '[Console][FrameworkBundle] [Random] Foo normal title',
                 'labels' => [

--- a/tests/Subscriber/AutoUpdateTitleWithLabelSubscriberTest.php
+++ b/tests/Subscriber/AutoUpdateTitleWithLabelSubscriberTest.php
@@ -45,17 +45,14 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
 
     public function testOnPullRequestLabeled()
     {
-        $event = new GitHubEvent([
-            'action' => 'labeled',
-            'number' => 1234,
-            'pull_request' => [
-                'title' => '[fwb][bar] Foo',
-                'labels' => [
-                    ['name' => 'FrameworkBundle', 'color' => 'dddddd'],
-                    ['name' => 'Console', 'color' => 'dddddd'],
-                ],
+        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request'=>[]], $this->repository);
+        $this->pullRequestApi->method('show')->willReturn([
+            'title' => '[fwb][bar] Foo',
+            'labels' => [
+                ['name' => 'FrameworkBundle', 'color' => 'dddddd'],
+                ['name' => 'Console', 'color' => 'dddddd'],
             ],
-        ], $this->repository);
+        ]);
 
         $this->dispatcher->dispatch($event, GitHubEvents::PULL_REQUEST);
         $responseData = $event->getResponseData();
@@ -67,16 +64,13 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
 
     public function testOnPullRequestLabeledCaseInsensitive()
     {
-        $event = new GitHubEvent([
-            'action' => 'labeled',
-            'number' => 1234,
-            'pull_request' => [
-                'title' => '[PHPunitbridge] Foo',
-                'labels' => [
-                    ['name' => 'PhpUnitBridge', 'color' => 'dddddd'],
-                ],
+        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request'=>[]], $this->repository);
+        $this->pullRequestApi->method('show')->willReturn([
+            'title' => '[PHPunitbridge] Foo',
+            'labels' => [
+                ['name' => 'PhpUnitBridge', 'color' => 'dddddd'],
             ],
-        ], $this->repository);
+        ]);
 
         $this->dispatcher->dispatch($event, GitHubEvents::PULL_REQUEST);
         $responseData = $event->getResponseData();
@@ -88,42 +82,14 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
 
     public function testOnPullRequestLabeledWithExisting()
     {
-        $event = new GitHubEvent([
-            'action' => 'labeled',
-            'number' => 1234,
-            'pull_request' => [
+        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request'=>[]], $this->repository);
+        $this->pullRequestApi->method('show')->willReturn([
                 'title' => '[Messenger] Fix JSON',
                 'labels' => [
                     ['name' => 'Status: Needs Review', 'color' => 'abcabc'],
                     ['name' => 'Messenger', 'color' => 'dddddd'],
                 ],
-            ],
-        ], $this->repository);
-
-        $this->dispatcher->dispatch($event, GitHubEvents::PULL_REQUEST);
-        $responseData = $event->getResponseData();
-        $this->assertEmpty($responseData);
-    }
-
-    /**
-     * If a user add two labels at the same time. We will get two webhooks simultaneously.
-     * We need to make sure that when we request the Github API it will return the changes
-     * from the first webhook.
-     */
-    public function testOnPullRequestLabeledTwice()
-    {
-        $this->pullRequestApi->method('show')->willReturn(['title' => '[Console][FrameworkBundle] Foo normal title']);
-        $event = new GitHubEvent([
-            'action' => 'labeled',
-            'number' => 1234,
-            'pull_request' => [
-                'title' => 'Foo normal title',
-                'labels' => [
-                    ['name' => 'FrameworkBundle', 'color' => 'dddddd'],
-                    ['name' => 'Console', 'color' => 'dddddd'],
-                ],
-            ],
-        ], $this->repository);
+            ]);
 
         $this->dispatcher->dispatch($event, GitHubEvents::PULL_REQUEST);
         $responseData = $event->getResponseData();
@@ -132,16 +98,13 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
 
     public function testRemoveLabel()
     {
-        $event = new GitHubEvent([
-            'action' => 'labeled',
-            'number' => 1234,
-            'pull_request' => [
+        $event = new GitHubEvent(['action' => 'labeled', 'number' => 1234, 'pull_request'=>[]], $this->repository);
+        $this->pullRequestApi->method('show')->willReturn([
                 'title' => '[Console][FrameworkBundle] [Random] Foo normal title',
                 'labels' => [
                     ['name' => 'Console', 'color' => 'dddddd'],
                 ],
-            ],
-        ], $this->repository);
+            ]);
 
         $this->dispatcher->dispatch($event, GitHubEvents::PULL_REQUEST);
         $responseData = $event->getResponseData();

--- a/tests/webhook_examples/pull_request.labeled.json
+++ b/tests/webhook_examples/pull_request.labeled.json
@@ -1,15 +1,15 @@
 {
   "action": "labeled",
-  "number": 3,
+  "number": 4711,
   "pull_request": {
-    "url": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/3",
+    "url": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/4711",
     "id": 513695993,
     "node_id": "MDExOlB1bGxSZXF1ZXN0NTEzNjk1OTkz",
-    "html_url": "https://github.com/carsonbot-playground/symfony/pull/3",
-    "diff_url": "https://github.com/carsonbot-playground/symfony/pull/3.diff",
-    "patch_url": "https://github.com/carsonbot-playground/symfony/pull/3.patch",
-    "issue_url": "https://api.github.com/repos/carsonbot-playground/symfony/issues/3",
-    "number": 3,
+    "html_url": "https://github.com/carsonbot-playground/symfony/pull/4711",
+    "diff_url": "https://github.com/carsonbot-playground/symfony/pull/4711.diff",
+    "patch_url": "https://github.com/carsonbot-playground/symfony/pull/4711.patch",
+    "issue_url": "https://api.github.com/repos/carsonbot-playground/symfony/issues/4711",
+    "number": 4711,
     "state": "open",
     "locked": false,
     "title": "Readme update",
@@ -125,10 +125,10 @@
       "closed_at": null
     },
     "draft": false,
-    "commits_url": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/3/commits",
-    "review_comments_url": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/3/comments",
+    "commits_url": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/4711/commits",
+    "review_comments_url": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/4711/comments",
     "review_comment_url": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/comments{/number}",
-    "comments_url": "https://api.github.com/repos/carsonbot-playground/symfony/issues/3/comments",
+    "comments_url": "https://api.github.com/repos/carsonbot-playground/symfony/issues/4711/comments",
     "statuses_url": "https://api.github.com/repos/carsonbot-playground/symfony/statuses/30e89eed45f0202a0ad3d5b47e968706d1cb3a42",
     "head": {
       "label": "carsonbot-playground:integration-test-branch",
@@ -378,25 +378,25 @@
     },
     "_links": {
       "self": {
-        "href": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/3"
+        "href": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/4711"
       },
       "html": {
-        "href": "https://github.com/carsonbot-playground/symfony/pull/3"
+        "href": "https://github.com/carsonbot-playground/symfony/pull/4711"
       },
       "issue": {
-        "href": "https://api.github.com/repos/carsonbot-playground/symfony/issues/3"
+        "href": "https://api.github.com/repos/carsonbot-playground/symfony/issues/4711"
       },
       "comments": {
-        "href": "https://api.github.com/repos/carsonbot-playground/symfony/issues/3/comments"
+        "href": "https://api.github.com/repos/carsonbot-playground/symfony/issues/4711/comments"
       },
       "review_comments": {
-        "href": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/3/comments"
+        "href": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/4711/comments"
       },
       "review_comment": {
         "href": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/comments{/number}"
       },
       "commits": {
-        "href": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/3/commits"
+        "href": "https://api.github.com/repos/carsonbot-playground/symfony/pulls/4711/commits"
       },
       "statuses": {
         "href": "https://api.github.com/repos/carsonbot-playground/symfony/statuses/30e89eed45f0202a0ad3d5b47e968706d1cb3a42"


### PR DESCRIPTION
Fixed issue introduced in #164 and #165

This is a nasty bug, it is all about race condition and it depends on what webhook is sent when. 
When a PR is opened, there is usually 5 or so webhook requests to carson. Some includes all lables, some do not. This PR make sure we query Github for the latest data before we make any changes. 