### PR TITLE
Add comment about squashing commits

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -14,6 +14,7 @@ parameters:
                 - 'App\Subscriber\CloseDraftPRSubscriber'
                 - 'App\Subscriber\UnsupportedBranchSubscriber'
                 - 'App\Subscriber\RemoveStalledLabelOnCommentSubscriber'
+                - 'App\Subscriber\AllowEditFromMaintainerSubscriber'
             secret: '%env(SYMFONY_SECRET)%'
 
         symfony/symfony-docs:
@@ -29,6 +30,7 @@ parameters:
                 - 'subscriber.symfony_docs.milestone'
                 - 'App\Subscriber\RemoveStalledLabelOnCommentSubscriber'
                 - 'App\Subscriber\UpdateMilestoneWhenLabeledWaitingCodeMergeSubscriber'
+                - 'App\Subscriber\AllowEditFromMaintainerSubscriber'
             secret: '%env(SYMFONY_DOCS_SECRET)%'
 
         # used in a functional test
@@ -48,6 +50,7 @@ parameters:
                 - 'App\Subscriber\UnsupportedBranchSubscriber'
                 - 'App\Subscriber\RemoveStalledLabelOnCommentSubscriber'
                 - 'App\Subscriber\UpdateMilestoneWhenLabeledWaitingCodeMergeSubscriber'
+                - 'App\Subscriber\AllowEditFromMaintainerSubscriber'
 
 services:
     _defaults:

--- a/src/Subscriber/AllowEditFromMaintainerSubscriber.php
+++ b/src/Subscriber/AllowEditFromMaintainerSubscriber.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Subscriber;
+
+use App\Api\Issue\IssueApi;
+use App\Api\PullRequest\PullRequestApi;
+use App\Event\GitHubEvent;
+use App\GitHubEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class AllowEditFromMaintainerSubscriber implements EventSubscriberInterface
+{
+    private $commentsApi;
+    private $pullRequestApi;
+
+    public function __construct(IssueApi $commentsApi, PullRequestApi $pullRequestApi)
+    {
+        $this->commentsApi = $commentsApi;
+        $this->pullRequestApi = $pullRequestApi;
+    }
+
+    public function onPullRequest(GitHubEvent $event)
+    {
+        $data = $event->getData();
+        if (!in_array($data['action'], ['opened', 'ready_for_review']) || ($data['pull_request']['draft'] ?? false)) {
+            return;
+        }
+
+        if ($data['pull_request']['maintainer_can_modify'] ?? true) {
+            return;
+        }
+
+        $repository = $event->getRepository();
+        $pullRequestNumber = $data['pull_request']['number'];
+        $this->commentsApi->commentOnIssue($repository, $pullRequestNumber, <<<TXT
+Please note that you need squash your commits before this PR can be merged. The maintainer can also squash the commits for you, but then you need to “Allow edits from maintainer” (there is a checkbox in the sidebar of the PR).
+
+Cheers!
+
+Carsonbot
+TXT
+);
+
+        $event->setResponseData([
+            'pull_request' => $pullRequestNumber,
+            'squash_comment' => true,
+        ]);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            GitHubEvents::PULL_REQUEST => 'onPullRequest',
+        ];
+    }
+}

--- a/tests/Controller/WebhookControllerTest.php
+++ b/tests/Controller/WebhookControllerTest.php
@@ -102,7 +102,7 @@ class WebhookControllerTest extends WebTestCase
             'Welcome first users' => [
                 'pull_request',
                 'pull_request.new_contributor.json',
-                ['pull_request' => 4, 'status_change' => 'needs_review',  'pr_labels' => [], 'new_contributor' => true],
+                ['pull_request' => 4, 'status_change' => 'needs_review',  'pr_labels' => [], 'new_contributor' => true, 'squash_comment' => true],
             ],
             'Waiting Code Merge' => [
                 'pull_request',

--- a/tests/webhook_examples/pull_request.draft_to_ready.json
+++ b/tests/webhook_examples/pull_request.draft_to_ready.json
@@ -361,7 +361,7 @@
     "merged_by": null,
     "comments": 0,
     "review_comments": 0,
-    "maintainer_can_modify": false,
+    "maintainer_can_modify": true,
     "commits": 1,
     "additions": 1,
     "deletions": 0,

--- a/tests/webhook_examples/pull_request.labeled.json
+++ b/tests/webhook_examples/pull_request.labeled.json
@@ -411,7 +411,7 @@
     "merged_by": null,
     "comments": 0,
     "review_comments": 0,
-    "maintainer_can_modify": false,
+    "maintainer_can_modify": true,
     "commits": 1,
     "additions": 3,
     "deletions": 1,

--- a/tests/webhook_examples/pull_request.new_contributor.json
+++ b/tests/webhook_examples/pull_request.new_contributor.json
@@ -340,7 +340,7 @@
     "merged_by": null,
     "comments": 0,
     "review_comments": 0,
-    "maintainer_can_modify": true,
+    "maintainer_can_modify": false,
     "commits": 1,
     "additions": 1,
     "deletions": 1,

--- a/tests/webhook_examples/pull_request.opened_draft.json
+++ b/tests/webhook_examples/pull_request.opened_draft.json
@@ -353,7 +353,7 @@
     "merged_by": null,
     "comments": 0,
     "review_comments": 0,
-    "maintainer_can_modify": false,
+    "maintainer_can_modify": true,
     "commits": 1,
     "additions": 1,
     "deletions": 0,

--- a/tests/webhook_examples/pull_request.opened_target_branch.json
+++ b/tests/webhook_examples/pull_request.opened_target_branch.json
@@ -352,7 +352,7 @@
     "merged_by": null,
     "comments": 0,
     "review_comments": 0,
-    "maintainer_can_modify": false,
+    "maintainer_can_modify": true,
     "commits": 1,
     "additions": 1,
     "deletions": 0,


### PR DESCRIPTION
Scenario 1) If a user opens a PR with multiple commits and don't allow maintainers to edit the branch. Then `gh` will squash the commits and **close** the PR. 

Scenario 2) If there are multiple authors of the commits in the PR, the maintainer need to squash the commits manually, push to the fork and then merge the PR. 

With these scenarios in mind, I think it is a good thing to let Carson tell the user that they need to squash the commits themselves or allow the maintainer to do it. 